### PR TITLE
update the package reference in functions worker extn 

### DIFF
--- a/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/TextCompletionInputAttribute.cs
@@ -5,7 +5,7 @@ using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 
 // TODO: Move this somewhere else and update the package to use Microsoft.Azure.WebJobs.Extensions.OpenAI
-[assembly: ExtensionInformation("CGillum.WebJobs.Extensions.OpenAI", "0.3.1-alpha")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.OpenAI", "0.5.0-alpha")]
 
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.OpenAI;


### PR DESCRIPTION
alpha nuget packages are published to nuget org, updating the reference in functions worker extension for text completion API

In future, this API will be updated to remove dependency on [legacy completions API of Open AI](https://platform.openai.com/docs/guides/text-generation/completions-api) and use newer [Completions API ](https://platform.openai.com/docs/guides/text-generation/chat-completions-api)

Present options:
Option 1: New deployments can't be done on Azure for model - text-davinci-003, hence this functionality can only be tested on deployments created in the past using the text-davinci-003 model in Azure.

Option 2: Directly use Open API Key for testing this legacy API for now.