### PR TITLE
Updating name of kusto startup project

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>10</MinorVersion>
+    <MinorVersion>11</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>

--- a/src/Functions.Worker.Extensions.OpenAI/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.OpenAI", "0.9.0-alpha")]
+[assembly: ExtensionInformation("Microsoft.Azure.WebJobs.Extensions.OpenAI", "0.10.0-alpha")]

--- a/src/WebJobs.Extensions.OpenAI.Kusto/OpenAIKusto.cs
+++ b/src/WebJobs.Extensions.OpenAI.Kusto/OpenAIKusto.cs
@@ -7,11 +7,11 @@ using Microsoft.Azure.WebJobs.Extensions.OpenAI.Search;
 using Microsoft.Extensions.DependencyInjection;
 
 // Reference: https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection
-[assembly: FunctionsStartup(typeof(OpenAIKustoWebJobsStartup))]
+[assembly: FunctionsStartup(typeof(OpenAIKusto))]
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto;
 
-class OpenAIKustoWebJobsStartup : FunctionsStartup
+class OpenAIKusto : FunctionsStartup
 {
     public override void Configure(IFunctionsHostBuilder builder)
     {


### PR DESCRIPTION
Updating name of kusto project. This change is needed for adding this project to the bundle.
While adding to the bundle the extension create the binary with the name 

{ "name": "OpenAIKustoWebJobsStartup", "typeName":"Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto.OpenAIKustoWebJobsStartup, WebJobs.Extensions.OpenAI.Kusto, Version=0.10.0.0, Culture=neutral, PublicKeyToken=null"},
 



