### PR TITLE
Create CosmosDB database and container if it doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,3 +412,9 @@ __azurite_db*__.json
 
 # python venv folder
 **/.venv/*
+
+# Azure Functions artifacts
+bin
+obj
+appsettings.json
+local.settings.json

--- a/samples/assistant/csharp-ooproc/AssistantSample/TodoManager.cs
+++ b/samples/assistant/csharp-ooproc/AssistantSample/TodoManager.cs
@@ -80,8 +80,18 @@ class CosmosDbTodoManager : ITodoManager
             throw new ArgumentNullException(nameof(cosmosClient));
         }
 
+        string? CosmosDatabaseName = Environment.GetEnvironmentVariable("CosmosDbDatabaseName");
+        string? CosmosContainerName = Environment.GetEnvironmentVariable("CosmosContainerName");
+
+        if (string.IsNullOrEmpty(CosmosDatabaseName) || string.IsNullOrEmpty(CosmosContainerName))
+        {
+            throw new ArgumentNullException("CosmosDatabaseName and CosmosContainerName must be set as environment variables or in local.settings.json");
+        }
+
         this.logger = loggerFactory.CreateLogger<CosmosDbTodoManager>();
-        this.container = cosmosClient.GetContainer("testdb", "my-todos");
+        cosmosClient.CreateDatabaseIfNotExistsAsync(CosmosDatabaseName).Wait();
+        cosmosClient.GetDatabase(CosmosDatabaseName).CreateContainerIfNotExistsAsync(CosmosContainerName, "/id").Wait();
+        this.container = cosmosClient.GetContainer(CosmosDatabaseName, CosmosContainerName);
     }
 
     public async Task AddTodoAsync(TodoItem todo)

--- a/samples/assistant/csharp-ooproc/AssistantSample/TodoManager.cs
+++ b/samples/assistant/csharp-ooproc/AssistantSample/TodoManager.cs
@@ -80,7 +80,7 @@ class CosmosDbTodoManager : ITodoManager
             throw new ArgumentNullException(nameof(cosmosClient));
         }
 
-        string? CosmosDatabaseName = Environment.GetEnvironmentVariable("CosmosDbDatabaseName");
+        string? CosmosDatabaseName = Environment.GetEnvironmentVariable("CosmosDatabaseName");
         string? CosmosContainerName = Environment.GetEnvironmentVariable("CosmosContainerName");
 
         if (string.IsNullOrEmpty(CosmosDatabaseName) || string.IsNullOrEmpty(CosmosContainerName))

--- a/samples/assistant/csharp-ooproc/AssistantSample/local.settings.json
+++ b/samples/assistant/csharp-ooproc/AssistantSample/local.settings.json
@@ -3,8 +3,8 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    // NOTE: The below is a local CosmosDB Emulator connection string. The account key is NOT a real secret!
-    // IMPORTANT: This file is tracked by source control. Do not use a real secret here! Use environment variables instead to override these settings.
-    // "CosmosDbConnectionString": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;"
+    "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
+    "CosmosDatabaseName": "todoDB",
+    "CosmosContainerName": "myTasks"
   }
 }


### PR DESCRIPTION
Added code to create database and container if they don't exist in CosmosDB sample. Also updated .gitignore to not check in local.settings.json and other Azure Functions artifacts