### PR TITLE
fix the kusto semantic search issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,12 @@ This extension depends on the [Azure AI OpenAI SDK](https://github.com/Azure/azu
 
 The following NuGet packages are available as part of this project.
 
-[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.WebJobs.Extensions.OpenAI.svg?label=microsoft.azure.webjobs.extensions.openai)](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.OpenAI)<br/>
-[![NuGet](
-https://img.shields.io/nuget/v/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.svg?label=microsoft.azure.functions.worker.extensions.openai
-)](
-https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.OpenAI
-)<br/>
-[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto.svg?label=microsoft.azure.webjobs.extensions.openai.kusto)](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto)<br/>
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.WebJobs.Extensions.OpenAI.svg?label=microsoft.azure.webjobs.extensions.openai)](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.OpenAI)
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.svg?label=microsoft.azure.functions.worker.extensions.openai)](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.OpenAI)
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto.svg?label=microsoft.azure.webjobs.extensions.openai.kusto)](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto)
 [![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch.svg?label=microsoft.azure.webjobs.extensions.openai.azureaisearch)](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch)
-[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.Kusto.svg?label=microsoft.azure.functions.worker.extensions.openAI.kusto)](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.Kusto)
-[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.AzureAISearch.svg?label=microsoft.azure.functions.worker.extensions.openAI.azureAISearch)](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.AzureAISearch)
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.Kusto.svg?label=microsoft.azure.functions.worker.extensions.openai.kusto)](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.Kusto)
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.AzureAISearch.svg?label=microsoft.azure.functions.worker.extensions.openai.azureaisearch)](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.OpenAI.AzureAISearch)
 
 ## Requirements
 

--- a/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
@@ -84,7 +84,7 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
                 Guid.NewGuid().ToString("N"),
                 Path.GetFileNameWithoutExtension(document.Title),
                 document.Embeddings.Request.Input![i],
-                GetEmbeddingsArray(document.Embeddings.Response.Data[i].Embedding),
+                GetEmbeddings(document.Embeddings.Response.Data[i].Embedding, false),
                 DateTime.UtcNow);
         }
 
@@ -110,7 +110,7 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
         // https://learn.microsoft.com/azure/data-explorer/kusto/query/queryparametersstatement
         // NOTE: Vector similarity reference:
         // https://techcommunity.microsoft.com/t5/azure-data-explorer-blog/azure-data-explorer-for-vector-similarity-search/ba-p/3819626
-        string embeddingsList = GetEmbeddingsString(request.Embeddings);
+        string embeddingsList = GetEmbeddings(request.Embeddings, true);
         string? tableName = request.ConnectionInfo.CollectionName?.Trim();
         if (string.IsNullOrEmpty(tableName) ||
             tableName.Contains('/') ||
@@ -169,29 +169,27 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
         return new KustoConnectionStringBuilder(connectionString);
     }
 
-    static string GetEmbeddingsString(ReadOnlyMemory<float> embedding)
+    static string GetEmbeddings(ReadOnlyMemory<float> embedding, bool returnString = false)
     {
         StringBuilder sb = new();
-        foreach (float value in embedding.Span)
-        {
-            sb.Append(value.ToString());
-            sb.Append(",");
-        }
-        sb.Length--; // remove the trailing comma
-        return sb.ToString();
-    }
 
-    static string GetEmbeddingsArray(ReadOnlyMemory<float> embedding)
-    {
-        StringBuilder sb = new();
-        sb.Append("[");
+        if (!returnString)
+        {
+            sb.Append("[");
+        }
+
         foreach (float value in embedding.Span)
         {
-            sb.Append(value.ToString());
-            sb.Append(",");
+            sb.Append(value).Append(",");
         }
+
         sb.Length--; // remove the trailing comma
-        sb.Append("]");
+
+        if (!returnString)
+        {
+            sb.Append("]");
+        }
+
         return sb.ToString();
     }
 }

--- a/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
@@ -84,7 +84,7 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
                 Guid.NewGuid().ToString("N"),
                 Path.GetFileNameWithoutExtension(document.Title),
                 document.Embeddings.Request.Input![i],
-                GetEmbeddingsString(document.Embeddings.Response.Data[i].Embedding),
+                GetEmbeddingsArray(document.Embeddings.Response.Data[i].Embedding),
                 DateTime.UtcNow);
         }
 
@@ -171,15 +171,27 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
 
     static string GetEmbeddingsString(ReadOnlyMemory<float> embedding)
     {
-        ReadOnlySpan<float> span = embedding.Span;
-        StringBuilder builder = new(span.Length * 10); // 9 is the longest string length of a float + 1 for comma
-
-        for (int i = 0; i < span.Length; i++)
+        StringBuilder sb = new();
+        foreach (float value in embedding.Span)
         {
-            builder.Append(span[i]).Append(',');
+            sb.Append(value.ToString());
+            sb.Append(",");
         }
-        builder.Remove(builder.Length - 1, 1);
+        sb.Length--; // remove the trailing comma
+        return sb.ToString();
+    }
 
-        return builder.ToString();
+    static string GetEmbeddingsArray(ReadOnlyMemory<float> embedding)
+    {
+        StringBuilder sb = new();
+        sb.Append("[");
+        foreach (float value in embedding.Span)
+        {
+            sb.Append(value.ToString());
+            sb.Append(",");
+        }
+        sb.Length--; // remove the trailing comma
+        sb.Append("]");
+        return sb.ToString();
     }
 }

--- a/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
@@ -84,7 +84,7 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
                 Guid.NewGuid().ToString("N"),
                 Path.GetFileNameWithoutExtension(document.Title),
                 document.Embeddings.Request.Input![i],
-                GetEmbeddings(document.Embeddings.Response.Data[i].Embedding, false),
+                GetEmbeddingsString(document.Embeddings.Response.Data[i].Embedding, true),
                 DateTime.UtcNow);
         }
 
@@ -110,7 +110,7 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
         // https://learn.microsoft.com/azure/data-explorer/kusto/query/queryparametersstatement
         // NOTE: Vector similarity reference:
         // https://techcommunity.microsoft.com/t5/azure-data-explorer-blog/azure-data-explorer-for-vector-similarity-search/ba-p/3819626
-        string embeddingsList = GetEmbeddings(request.Embeddings, true);
+        string embeddingsList = GetEmbeddingsString(request.Embeddings, false);
         string? tableName = request.ConnectionInfo.CollectionName?.Trim();
         if (string.IsNullOrEmpty(tableName) ||
             tableName.Contains('/') ||
@@ -169,11 +169,11 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
         return new KustoConnectionStringBuilder(connectionString);
     }
 
-    static string GetEmbeddings(ReadOnlyMemory<float> embedding, bool returnString = false)
+    static string GetEmbeddingsString(ReadOnlyMemory<float> embedding, bool asArray)
     {
         StringBuilder sb = new();
 
-        if (!returnString)
+        if (asArray)
         {
             sb.Append("[");
         }
@@ -185,7 +185,7 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
 
         sb.Length--; // remove the trailing comma
 
-        if (!returnString)
+        if (asArray)
         {
             sb.Append("]");
         }

--- a/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.Kusto/KustoSearchProvider.cs
@@ -169,11 +169,11 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
         return new KustoConnectionStringBuilder(connectionString);
     }
 
-    static string GetEmbeddingsString(ReadOnlyMemory<float> embedding, bool asArray)
+    static string GetEmbeddingsString(ReadOnlyMemory<float> embedding, bool asJsonArray)
     {
         StringBuilder sb = new();
 
-        if (asArray)
+        if (asJsonArray)
         {
             sb.Append("[");
         }
@@ -185,7 +185,7 @@ sealed class KustoSearchProvider : ISearchProvider, IDisposable
 
         sb.Length--; // remove the trailing comma
 
-        if (asArray)
+        if (asJsonArray)
         {
             sb.Append("]");
         }


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-openai-extension/issues/49

Kusto expects the embeddings to be stored in a specific format like [0.007887467741966248, -0.02706138789653778, -...]
An array subscript “[]” was missed while storing embeddings, this resulted in incorrect similarity comparison.