### PR TITLE
add overlapping logic in chunking and share tips on improving context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ Starting v0.13.0 for Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto, it will ma
 Starting v0.1.0 for Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch, it will maintain its own [Changelog](./src/WebJobs.Extensions.OpenAI)
 
 ## v0.14.0 - Unreleased
+
 ### Changes
+
 - Updated Azure.Identity from 1.10.4 to 1.11.0
+
+### Breaking Changes
+
+- Overlapping introduced to chunking in embeddings with word breaks and sentence endings.
   
 ## v0.13.0 - 2024/04/05
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The semantic search feature allows you to import documents into a vector databas
 
  The supported list of vector databases is extensible, and more can be added by authoring a specially crafted NuGet package. Visit the currently supported vector specific folder for specific usage information:
 
-* [Azure AI Search](https://learn.microsoft.com/azure/search/search-create-service-portal) - [source code](./src/WebJobs.Extensions.OpenAI.AISearch/)
+* [Azure AI Search](https://learn.microsoft.com/azure/search/search-create-service-portal) - See [source code](./src/WebJobs.Extensions.OpenAI.AISearch/)
 * [Azure Data Explorer](https://azure.microsoft.com/services/data-explorer/) - See [source code](./src/WebJobs.Extensions.OpenAI.Kusto/)
 
  More may be added over time.
@@ -306,9 +306,12 @@ public static async Task<SemanticSearchOutputResponse> IngestFile(
 }
 ```
 
+**Tip** - To improve context preservation between chunks in case of large documents, specify the max overlap between chunks and also the chunk size. The default values for `MaxChunkSize` and `MaxOverlap` are 8 * 1024 and 128 characters respectively.
+
 #### [C# document query example](./samples/rag-aisearch/csharp-ooproc/FilePrompt.cs)
 
 This HTTP trigger function takes a query prompt as input, pulls in semantically similar document chunks into a prompt, and then sends the combined prompt to OpenAI. The results are then made available to the function, which simply returns that chat response to the caller.
+**Tip** - To improve the knowledge for OpenAI model, the number of result sets being sent to the model with system prompt can be increased with binding property - `MaxKnowledgeCount` which has default value as 1. Also, the `SystemPrompt` in SemanticSearchRequest can be tweaked as per user instructions on how to process the knowledge sets being appended to it.
 
 ```csharp
 public class SemanticSearchRequest

--- a/src/Functions.Worker.Extensions.OpenAI/Embeddings/EmbeddingsInputAttribute.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/Embeddings/EmbeddingsInputAttribute.cs
@@ -40,6 +40,11 @@ public class EmbeddingsInputAttribute : InputBindingAttribute
     public int MaxChunkLength { get; set; } = 8 * 1024; // REVIEW: Is 8K a good default?
 
     /// <summary>
+    /// Gets or sets the maximum number of characters to overlap between chunks.
+    /// </summary>
+    public int MaxOverlap { get; set; } = 128;
+
+    /// <summary>
     /// Gets the input to generate embeddings for.
     /// </summary>
     public string Input { get; }

--- a/src/WebJobs.Extensions.OpenAI.AzureAISearch/CHANGELOG.md
+++ b/src/WebJobs.Extensions.OpenAI.AzureAISearch/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.1.0 - Unreleased
+## v0.2.0 - Unreleased
+
+### Changed
+
+- Updated Microsoft.Azure.WebJobs.Extensions.OpenAI to 0.14.0
+
+## v0.1.0 - 2024/04/05
 
 ### Added
 

--- a/src/WebJobs.Extensions.OpenAI.Kusto/CHANGELOG.md
+++ b/src/WebJobs.Extensions.OpenAI.Kusto/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.13.0 - Unreleased
+## v0.14.0 - Unreleased
+
+### Changed
+
+- Updated Microsoft.Azure.WebJobs.Extensions.OpenAI to 0.14.0
+
+## v0.13.0 - 2024/04/05
 
 ### Added and Breaking Change
 

--- a/src/WebJobs.Extensions.OpenAI/Embeddings/EmbeddingsAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/Embeddings/EmbeddingsAttribute.cs
@@ -119,8 +119,8 @@ public sealed class EmbeddingsAttribute : Attribute
         sentenceEndings ??= new[] { '.', '!', '?' };
         wordBreaks ??= new[] { ',', ';', ':', ' ', '(', ')', '[', ']', '{', '}', '\t', '\n' };
 
-        var sentenceEndingsSet = new HashSet<char>(sentenceEndings);
-        var wordBreaksSet = new HashSet<char>(wordBreaks);
+        HashSet<char> sentenceEndingsSet = new (sentenceEndings);
+        HashSet<char> wordBreaksSet = new (wordBreaks);
 
         int bytesRead;
         while ((bytesRead = reader.Read(buffer, startIndex, maxChunkSize - startIndex)) > 0)

--- a/src/WebJobs.Extensions.OpenAI/Embeddings/EmbeddingsAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/Embeddings/EmbeddingsAttribute.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenAI.Embeddings;
 [AttributeUsage(AttributeTargets.Parameter)]
 public sealed class EmbeddingsAttribute : Attribute
 {
+    static readonly char[] sentenceEndingsDefault = new[] { '.', '!', '?' };
+    static readonly char[] wordBreaksDefault = new[] { ',', ';', ':', ' ', '(', ')', '[', ']', '{', '}', '\t', '\n' };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EmbeddingsAttribute"/> class with the specified input.
     /// </summary>
@@ -116,11 +119,11 @@ public sealed class EmbeddingsAttribute : Attribute
         char[] buffer = new char[maxChunkSize];
         int startIndex = 0;
 
-        sentenceEndings ??= new[] { '.', '!', '?' };
-        wordBreaks ??= new[] { ',', ';', ':', ' ', '(', ')', '[', ']', '{', '}', '\t', '\n' };
+        sentenceEndings ??= sentenceEndingsDefault;
+        wordBreaks ??= wordBreaksDefault;
 
-        HashSet<char> sentenceEndingsSet = new (sentenceEndings);
-        HashSet<char> wordBreaksSet = new (wordBreaks);
+        HashSet<char> sentenceEndingsSet = new(sentenceEndings);
+        HashSet<char> wordBreaksSet = new(wordBreaks);
 
         int bytesRead;
         while ((bytesRead = reader.Read(buffer, startIndex, maxChunkSize - startIndex)) > 0)


### PR DESCRIPTION
- added overlap between chunks, default value 128 characters
- added logic to cater to sentence endings and word breaks
- overlap will only start from a word break.
- added tips to improve context and tweaking the system prompt in README

addresses https://github.com/Azure/azure-functions-pyfx-planning/issues/271