### PR TITLE
Adding Dockerfile for the Assistants feature

### DIFF
--- a/samples/assistant/csharp-ooproc/AssistantSample/Dockerfile
+++ b/samples/assistant/csharp-ooproc/AssistantSample/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+
+# Add support for .NET 8 (required for Azure Functions build process)
+COPY --from=mcr.microsoft.com/dotnet/sdk:8.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+
+# Environment variable for getting test version
+ENV testVersion=99.99.99-test
+
+# Need to build the full repo to get the samples to work
+# Copy the directory from your local machine into the Docker image
+#COPY . /root/samples/assistant/csharp-ooproc/AssistantSample
+
+COPY . /root
+RUN cd /root/samples/assistant/csharp-ooproc/AssistantSample 
+ RUN   mkdir -p /home/site/wwwroot 
+ RUN   mkdir ~/NuGetPackagesLocal 
+  RUN  dotnet build /root/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj -p:WebJobsVersion=$testVersion -p:Version=$testVersion 
+  RUN  cp "/root/src/WebJobs.Extensions.OpenAI/bin/Debug/Microsoft.Azure.WebJobs.Extensions.OpenAI.${testVersion}.nupkg" ~/NuGetPackagesLocal 
+  WORKDIR /root/samples/assistant/csharp-ooproc/AssistantSample
+  RUN  dotnet nuget add source ~/NuGetPackagesLocal --configfile  ~/.nuget/NuGet/NuGet.Config 
+  RUN  dotnet build -c Release -p:WebJobsVersion=$testVersion -p:Version=$testVersion --configfile ~/.nuget/NuGet/NuGet.Config 
+   RUN dotnet publish --no-restore -c Release -o /home/site/wwwroot -p:WebJobsVersion=$testVersion -p:Version=$testVersion
+
+# The final image is based on the Azure Functions 4.0 runtime image
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+
+# This is the standard setup for Azure Functions running in Docker containers
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+COPY --from=build-env ["/home/site/wwwroot", "/home/site/wwwroot"]


### PR DESCRIPTION
This pull request includes significant changes to the `Dockerfile` in the `samples/assistant/csharp-ooproc/AssistantSample` directory. The changes primarily revolve around adding support for .NET 8, setting up environment variables, building the repository, and configuring the Azure Functions runtime environment.

Here are the key changes:

* [`Dockerfile`](diffhunk://#diff-36f5f332816661a2a4e4861987327da54da6d8fbeaffc5a86e3d721b86d0b10cR1-R30): The base image has been updated to use .NET 8 SDK, and support for .NET 8 has been added to the Azure Functions build process.
* [`Dockerfile`](diffhunk://#diff-36f5f332816661a2a4e4861987327da54da6d8fbeaffc5a86e3d721b86d0b10cR1-R30): An environment variable `testVersion` has been added to fetch the test version.
* [`Dockerfile`](diffhunk://#diff-36f5f332816661a2a4e4861987327da54da6d8fbeaffc5a86e3d721b86d0b10cR1-R30): The repository is now fully built within the Docker image, with the directory being copied from the local machine into the Docker image. Several directories are created in the process, and the `dotnet build` and `dotnet publish` commands are used to build and publish the project.
* [`Dockerfile`](diffhunk://#diff-36f5f332816661a2a4e4861987327da54da6d8fbeaffc5a86e3d721b86d0b10cR1-R30): The final image is now based on the Azure Functions 4.0 runtime image, with the standard setup for Azure Functions running in Docker containers.