### PR TITLE
chore: input bindings

### DIFF
--- a/samples/assistant/nodejs/src/functions/assistantApis.ts
+++ b/samples/assistant/nodejs/src/functions/assistantApis.ts
@@ -29,7 +29,7 @@ app.http('CreateAssistant', {
 })
 
 
-const assistantPostInput = output.generic({
+const assistantPostInput = input.generic({
     type: 'assistantPost',
     id: '{assistantId}',
     model: '%CHAT_MODEL_DEPLOYMENT_NAME%',

--- a/samples/chat/nodejs/src/functions/app.ts
+++ b/samples/chat/nodejs/src/functions/app.ts
@@ -43,7 +43,7 @@ app.http('GetChatState', {
 });
 
 
-const assistantPostInput = output.generic({
+const assistantPostInput = input.generic({
     type: 'assistantPost',
     id: '{chatID}',
     model: '%CHAT_MODEL_DEPLOYMENT_NAME%',


### PR DESCRIPTION
Fix nodejs sanples.  
Input binding object should be generated from `input.generic`.