### PR TITLE
Updating Python samples to use newest library version

### DIFF
--- a/samples/assistant/README.md
+++ b/samples/assistant/README.md
@@ -179,6 +179,7 @@ Also note that the storage of chat history is done via table storage. You may co
 
 1. Clone this repo and navigate to the sample folder.
 1. Use a terminal window to navigate to the sample directory (e.g. `cd samples/assistant/csharp-ooproc`)
+2. If using python, run `pip -r requirements.txt` to install the correct library version.
 1. Run `func start` to build and run the sample function app
 
     If successful, you should see the following output from the `func` command:

--- a/samples/assistant/python/local.settings.json
+++ b/samples/assistant/python/local.settings.json
@@ -8,6 +8,7 @@
     "CosmosDatabaseName": "testdb",
     "CosmosContainerName": "my-todos",
     "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
-    "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
+    "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/assistant/python/requirements.txt
+++ b/samples/assistant/python/requirements.txt
@@ -2,5 +2,5 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.20.0b2
 azure-cosmos

--- a/samples/assistant/python/requirements.txt
+++ b/samples/assistant/python/requirements.txt
@@ -2,5 +2,5 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions==1.20.0b2
+azure-functions>=1.20.0b2
 azure-cosmos

--- a/samples/chat/README.md
+++ b/samples/chat/README.md
@@ -24,7 +24,7 @@ Please refer to the root level [README](../../README.md#requirements) for prereq
     | .NET oo-proc | `cd samples/chat/csharp-ooproc && func start` |
     | Node.js | `cd samples/chat/nodejs && npm install && dotnet build --output bin && npm run build && npm run start` |
     | PowerShell | `cd samples/chat/powershell && dotnet build --output bin && func start` |
-    | Python | `cd samples/chat/python && func start` |
+    | Python | `cd samples/chat/python && pip install -r requirements.txt && func start` |
     | Java | `cd samples/chat/java && mvn clean package && dotnet build && mvn azure-functions:run` |
 
     If successful, you should see the following output from the `func` command:

--- a/samples/chat/python/local.settings.json
+++ b/samples/chat/python/local.settings.json
@@ -5,6 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
-    "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
+    "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/chat/python/requirements.txt
+++ b/samples/chat/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.20.0b2

--- a/samples/chat/python/requirements.txt
+++ b/samples/chat/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions==1.20.0b2
+azure-functions>=1.20.0b2

--- a/samples/embeddings/README.md
+++ b/samples/embeddings/README.md
@@ -61,7 +61,8 @@ Please refer to the [root README](../../README.md#requirements) for common prere
 
 1. Clone this repo and navigate to the sample folder.
 1. Use a terminal window to navigate to the sample directory (e.g. `cd samples/embeddings/csharp-ooproc/Embeddings`)
-1. Run `func start` to build and run the sample function app
+2. If using python, run `pip -r requirements.txt` to install the correct library version.
+2. Run `func start` to build and run the sample function app
 
     If successful, you should see the following output from the `func` command:
 

--- a/samples/embeddings/python/local.settings.json
+++ b/samples/embeddings/python/local.settings.json
@@ -5,6 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
-    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
+    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/embeddings/python/requirements.txt
+++ b/samples/embeddings/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.20.0b2

--- a/samples/embeddings/python/requirements.txt
+++ b/samples/embeddings/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions==1.20.0b2
+azure-functions>=1.20.0b2

--- a/samples/rag-aisearch/README.md
+++ b/samples/rag-aisearch/README.md
@@ -54,7 +54,7 @@ Once you have an Azure AI Search resource, you can run the sample by following t
     ```sh
     dotnet build --output bin
     ```
-
+2. If using python, run `pip -r requirements.txt` to install the correct library version.
 1. Build and start the app
 
     ```sh

--- a/samples/rag-aisearch/python/local.settings.json
+++ b/samples/rag-aisearch/python/local.settings.json
@@ -7,6 +7,7 @@
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
     "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
-    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
+    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/rag-aisearch/python/requirements.txt
+++ b/samples/rag-aisearch/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.20.0b2

--- a/samples/rag-aisearch/python/requirements.txt
+++ b/samples/rag-aisearch/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions==1.20.0b2
+azure-functions>=1.20.0b2

--- a/samples/rag-cosmosdb/README.md
+++ b/samples/rag-cosmosdb/README.md
@@ -49,7 +49,7 @@ Once you have an Cosmos DB resource, you can run the sample by following these s
     ```sh
     dotnet build --output bin
     ```
-
+2. If using python, run `pip -r requirements.txt` to install the correct library version.
 1. Build and start the app
 
     ```sh

--- a/samples/rag-cosmosdb/python/local.settings.json
+++ b/samples/rag-cosmosdb/python/local.settings.json
@@ -7,6 +7,7 @@
     "CosmosDBMongoVCoreConnectionString": "",
     "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
-    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
+    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/rag-cosmosdb/python/requirements.txt
+++ b/samples/rag-cosmosdb/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.20.0b2

--- a/samples/rag-cosmosdb/python/requirements.txt
+++ b/samples/rag-cosmosdb/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions==1.20.0b2
+azure-functions>=1.20.0b2

--- a/samples/rag-kusto/README.md
+++ b/samples/rag-kusto/README.md
@@ -49,7 +49,7 @@ Once you have a Kusto cluster and database, you can run the sample by following 
     ```sh
     dotnet build --output bin
     ```
-
+2. If using python, run `pip -r requirements.txt` to install the correct library version.
 1. Build and start the app
 
     ```sh

--- a/samples/rag-kusto/python/local.settings.json
+++ b/samples/rag-kusto/python/local.settings.json
@@ -7,6 +7,7 @@
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
     "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
-    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small"
+    "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/rag-kusto/python/requirements.txt
+++ b/samples/rag-kusto/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.20.0b2

--- a/samples/rag-kusto/python/requirements.txt
+++ b/samples/rag-kusto/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions==1.20.0b2
+azure-functions>=1.20.0b2

--- a/samples/textcompletion/README.md
+++ b/samples/textcompletion/README.md
@@ -24,7 +24,7 @@ Please refer to the root level [README](../../README.md#requirements) for prereq
     | .NET oo-proc | `cd samples/textcompletion/csharp-ooproc && dotnet build && cd bin/debug/net6.0 && func start` |
     | Node.js | `cd samples/textcompletion/nodejs && npm install && dotnet build --output bin && npm run build && npm run start` |
     | PowerShell | `cd samples/textcompletion/powershell && dotnet build --output bin && func start` |
-    | Python | `cd samples/textcompletion/python && func start` |
+    | Python | `cd samples/textcompletion/python && pip install -r requirements.txt && func start` |
     | Java | `cd samples/textcompletion/java && mvn clean package && dotnet build && mvn azure-functions:run` |
 
     If successful, you should see the following output from the `func` command:

--- a/samples/textcompletion/python/local.settings.json
+++ b/samples/textcompletion/python/local.settings.json
@@ -5,6 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
-    "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
+    "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/textcompletion/python/requirements.txt
+++ b/samples/textcompletion/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions
+azure-functions==1.20.0b2

--- a/samples/textcompletion/python/requirements.txt
+++ b/samples/textcompletion/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions==1.20.0b2
+azure-functions>=1.20.0b2


### PR DESCRIPTION
The decorators are a new change only in version `azure-functions `1.20.0b2 and above. The version brought in from core tools is older, so `PYTHON_ISOLATE_WORKER_DEPENDENCIES=1` is necessary to pull from the user's azure-functions.

These changes add PIWD=1 to the `local.settings.json` file and specifies the specific version of `azure-functions` needed in the `requirements.txt` file. For sample `READMEs`, the steps are updated to run `pip install -r requirements.txt` so that this version of the library is installed.

This can be removed when there's a core tools release with the worker bringing a library version of 1.20.0b2 or above, but no ETA for that right now.

Fixes https://github.com/Azure/azure-functions-openai-extension/issues/82