### PR TITLE
Fix Node Assistant sample errors

### DIFF
--- a/samples/assistant/nodejs/extensions.csproj
+++ b/samples/assistant/nodejs/extensions.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net60</TargetFramework>
+	  <WarningsAsErrors></WarningsAsErrors>
+	  <DefaultItemExcludes>**</DefaultItemExcludes>
+    <OutDir>bin</OutDir>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.*" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <!-- Locally build and reference the extension -->
+    <ProjectReference Include="../../../src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/assistant/nodejs/src/functions/assistantSkills.ts
+++ b/samples/assistant/nodejs/src/functions/assistantSkills.ts
@@ -3,6 +3,7 @@
 
 import { InvocationContext, app, trigger } from "@azure/functions"
 import { TodoItem, ITodoManager, CreateTodoManager } from "../services/todoManager"
+import { randomUUID } from 'crypto';
 
 const todoManager: ITodoManager = CreateTodoManager()
 
@@ -18,7 +19,7 @@ app.generic('AddTodo', {
 
         context.log(`Adding todo: ${taskDescription}`)
 
-        const todoId = crypto.randomUUID().substring(0, 6)
+        const todoId = randomUUID().substring(0, 6)
         return todoManager.AddTodo(new TodoItem(todoId, taskDescription))
     }
 })


### PR DESCRIPTION
When testing the Assistant sample for Node.js, I hit two errors:

- The sample app failed to build because there was no `csproj` file
- The `AddTodo` was failing due to the `crypto` module 

![image](https://github.com/Azure/azure-functions-openai-extension/assets/16215208/0032b188-82a7-4807-b09e-2cd1c7c0602b)
