### PR TITLE
Updating Python library version

### DIFF
--- a/samples/assistant/python/requirements.txt
+++ b/samples/assistant/python/requirements.txt
@@ -2,5 +2,5 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.20.0b2
+azure-functions>=1.20.0b4
 azure-cosmos

--- a/samples/chat/python/requirements.txt
+++ b/samples/chat/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.20.0b2
+azure-functions>=1.20.0b4

--- a/samples/embeddings/python/requirements.txt
+++ b/samples/embeddings/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.20.0b2
+azure-functions>=1.20.0b4

--- a/samples/rag-aisearch/python/requirements.txt
+++ b/samples/rag-aisearch/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.20.0b2
+azure-functions>=1.20.0b4

--- a/samples/rag-cosmosdb/python/requirements.txt
+++ b/samples/rag-cosmosdb/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.20.0b2
+azure-functions>=1.20.0b4

--- a/samples/rag-kusto/python/requirements.txt
+++ b/samples/rag-kusto/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.20.0b2
+azure-functions>=1.20.0b4

--- a/samples/textcompletion/python/requirements.txt
+++ b/samples/textcompletion/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.20.0b2
+azure-functions>=1.20.0b4


### PR DESCRIPTION
A bug was discovered where the AssistantSkillTrigger type had a typo in the python sdk. A new version was released with the fix. This updates the requirements.txt files in the python samples to now pull from that library version or greater.