### PR TITLE
fix: remove vulnerabilities from java 8 parent in java func openai lib

### DIFF
--- a/java-library/pom.xml
+++ b/java-library/pom.xml
@@ -8,12 +8,6 @@
 	<version>0.4.0-preview</version>
 	<packaging>jar</packaging>
 
-	<parent>
-		<groupId>com.microsoft.maven</groupId>
-		<artifactId>java-8-parent</artifactId>
-		<version>8.0.1</version>
-	</parent>
-
 	<name>Microsoft Azure Functions Java Libary for OpenAI</name>
 	<description>This package contains all Java interfaces and annotations to interact with Microsoft Azure functions java runtime.</description>
 	<url>https://azure.microsoft.com/en-us/services/functions</url>


### PR DESCRIPTION
confirmed with Manvir there is no e2e tests yet. this parent brings in vulnerability (jackson-databind:2.9.8) and is not required. 
manual testing done in local and tested working
![{406F9F50-69FA-49AE-AD7C-1EEB3D416670}](https://github.com/user-attachments/assets/5b51178c-7412-4b31-b089-faecced2ff99)

![{A4493EB2-B391-49F3-ABC8-DDB73CD6223C}](https://github.com/user-attachments/assets/f3e0c197-0f19-41a6-a932-d6d10dc10332)

java function missing e2e tests on openai extension, will add in java worker.
fix https://github.com/Azure/azure-functions-pyfx-planning/issues/403


![{EDFF6EA8-6F6B-4C9F-92B2-B9148F381636}](https://github.com/user-attachments/assets/cb45d9d2-39b4-44f0-9cc9-a1ed957b4e5e)
