### PR TITLE
Fix assistant skill trigger handling of return values

### DIFF
--- a/OpenAI-Extension.sln
+++ b/OpenAI-Extension.sln
@@ -90,6 +90,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SemanticCosmosDBSearchEmbed
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssistantSample", "samples\assistant\csharp-ooproc\AssistantSample.csproj", "{4057D224-2A7C-4186-86D6-66F79542561B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assistant-legacy", "assistant-legacy", "{20E3EDFF-0628-4AAC-BAD2-30E2C6862C30}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssistantSample", "samples\assistant\csharp-legacy\AssistantSample.csproj", "{FF68DF4B-82A3-4032-8673-91FCBBD1F8FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -160,6 +164,10 @@ Global
 		{4057D224-2A7C-4186-86D6-66F79542561B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4057D224-2A7C-4186-86D6-66F79542561B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4057D224-2A7C-4186-86D6-66F79542561B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF68DF4B-82A3-4032-8673-91FCBBD1F8FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF68DF4B-82A3-4032-8673-91FCBBD1F8FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF68DF4B-82A3-4032-8673-91FCBBD1F8FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF68DF4B-82A3-4032-8673-91FCBBD1F8FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -188,6 +196,8 @@ Global
 		{24193510-C974-42E2-AE1F-1097E16A2445} = {865C9FB5-1043-47BE-B650-25A2B42030A3}
 		{D4EC72DC-5B7C-4C24-AA72-A18EF04041BC} = {24193510-C974-42E2-AE1F-1097E16A2445}
 		{4057D224-2A7C-4186-86D6-66F79542561B} = {C5578BE5-AAC7-4616-9A35-41CA5903882A}
+		{20E3EDFF-0628-4AAC-BAD2-30E2C6862C30} = {865C9FB5-1043-47BE-B650-25A2B42030A3}
+		{FF68DF4B-82A3-4032-8673-91FCBBD1F8FB} = {20E3EDFF-0628-4AAC-BAD2-30E2C6862C30}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {05A7A679-3A53-45B5-AE93-4313655E127D}

--- a/samples/assistant/csharp-legacy/AssistantApis.cs
+++ b/samples/assistant/csharp-legacy/AssistantApis.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenAI.Assistants;
+using Microsoft.Azure.WebJobs.Extensions.OpenAI.Models;
+
+namespace AssistantSample;
+
+/// <summary>
+/// Defines HTTP APIs for interacting with assistants.
+/// </summary>
+static class AssistantApis
+{
+    /// <summary>
+    /// HTTP PUT function that creates a new assistant chat bot with the specified ID.
+    /// </summary>
+    [FunctionName(nameof(CreateAssistant))]
+    public static async Task<IActionResult> CreateAssistant(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "assistants/{assistantId}")] HttpRequest req,
+        string assistantId,
+        [AssistantCreate] IAsyncCollector<AssistantCreateRequest> createRequests)
+    {
+        string instructions =
+            """
+            Don't make assumptions about what values to plug into functions.
+            Ask for clarification if a user request is ambiguous.
+            """;
+
+        await createRequests.AddAsync(new AssistantCreateRequest(assistantId, instructions));
+        var responseJson = new { assistantId };
+        return new ObjectResult(responseJson) { StatusCode = 202 };
+    }
+
+    /// <summary>
+    /// HTTP POST function that sends user prompts to the assistant chat bot.
+    /// </summary>
+    [FunctionName(nameof(PostUserQuery))]
+    public static IActionResult PostUserQuery(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "assistants/{assistantId}")] HttpRequest req,
+        string assistantId,
+        [AssistantPost("{assistantId}", "{Query.message}")] AssistantState updatedState)
+    {
+        return new OkObjectResult(updatedState.RecentMessages.LastOrDefault()?.Content ?? "No response returned.");
+    }
+
+    /// <summary>
+    /// HTTP GET function that queries the conversation history of the assistant chat bot.
+    /// </summary>
+    [FunctionName(nameof(GetChatState))]
+    public static AssistantState GetChatState(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "assistants/{assistantId}")] HttpRequest req,
+        string assistantId,
+        [AssistantQuery("{assistantId}", TimestampUtc = "{Query.timestampUTC}")] AssistantState state)
+    {
+        return state;
+    }
+}

--- a/samples/assistant/csharp-legacy/AssistantSample.csproj
+++ b/samples/assistant/csharp-legacy/AssistantSample.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\WebJobs.Extensions.OpenAI\WebJobs.Extensions.OpenAI.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/samples/assistant/csharp-legacy/AssistantSkills.cs
+++ b/samples/assistant/csharp-legacy/AssistantSkills.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.OpenAI.Assistants;
+using Microsoft.Extensions.Logging;
+
+namespace AssistantSample;
+
+/// <summary>
+/// Defines assistant skills that can be triggered by the assistant chat bot.
+/// </summary>
+public class AssistantSkills
+{
+    readonly ITodoManager todoManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssistantSkills"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This constructor is called by the Azure Functions runtime's dependency injection container.
+    /// </remarks>
+    public AssistantSkills(ITodoManager todoManager)
+    {
+        this.todoManager = todoManager ?? throw new ArgumentNullException(nameof(todoManager));
+    }
+
+    /// <summary>
+    /// Called by the assistant to create new todo tasks.
+    /// </summary>
+    [FunctionName(nameof(AddTodo))]
+    public Task AddTodo([AssistantSkillTrigger("Create a new todo task")] string taskDescription, ILogger log)
+    {
+        if (string.IsNullOrEmpty(taskDescription))
+        {
+            throw new ArgumentException("Task description cannot be empty");
+        }
+
+        log.LogInformation("Adding todo: {task}", taskDescription);
+
+        string todoId = Guid.NewGuid().ToString()[..6];
+        return this.todoManager.AddTodoAsync(new TodoItem(todoId, taskDescription));
+    }
+
+    /// <summary>
+    /// Called by the assistant to fetch the list of previously created todo tasks.
+    /// </summary>
+    [FunctionName(nameof(GetTodos))]
+    public async Task<IReadOnlyList<TodoItem>> GetTodos(
+        [AssistantSkillTrigger("Fetch the list of previously created todo tasks")] object inputIgnored,
+        ILogger log)
+    {
+        log.LogInformation("Fetching list of todos");
+
+        IReadOnlyList<TodoItem> results = await this.todoManager.GetTodosAsync();
+        return results;
+    }
+}

--- a/samples/assistant/csharp-legacy/Properties/launchSettings.json
+++ b/samples/assistant/csharp-legacy/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "AssistantSample": {
+    "AssistantLegacySample": {
     "commandName": "Project",
     "commandLineArgs": "--port 7071",
     "launchBrowser": false

--- a/samples/assistant/csharp-legacy/Properties/launchSettings.json
+++ b/samples/assistant/csharp-legacy/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "AssistantSample": {
+    "commandName": "Project",
+    "commandLineArgs": "--port 7071",
+    "launchBrowser": false
+    }
+  }
+}

--- a/samples/assistant/csharp-legacy/Startup.cs
+++ b/samples/assistant/csharp-legacy/Startup.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: FunctionsStartup(typeof(AssistantSample.Startup))]
+
+namespace AssistantSample;
+
+/// <summary>
+/// Functions startup extension that configures the dependency injection container with an
+/// appropriate implementation of <see cref="ITodoManager"/>.
+/// </summary>
+class Startup : FunctionsStartup
+{
+    public override void Configure(IFunctionsHostBuilder builder)
+    {
+        string? cosmosDbConnectionString = Environment.GetEnvironmentVariable("CosmosDbConnectionString");
+        if (string.IsNullOrEmpty(cosmosDbConnectionString))
+        {
+            // Use an in-memory implementation of ITodoManager if no CosmosDB connection string is provided
+            builder.Services.AddSingleton<ITodoManager, InMemoryTodoManager>();
+        }
+        else
+        {
+            // Use CosmosDB implementation of ITodoManager
+            // Reference: https://learn.microsoft.com/azure/cosmos-db/nosql/best-practice-dotnet#best-practices-for-http-connections
+            SocketsHttpHandler socketsHttpHandler = new()
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            };
+
+            builder.Services.AddSingleton(socketsHttpHandler);
+
+            builder.Services.AddSingleton(serviceProvider =>
+            {
+                SocketsHttpHandler socketsHttpHandler = serviceProvider.GetRequiredService<SocketsHttpHandler>();
+                CosmosClientOptions cosmosClientOptions = new()
+                {
+                    HttpClientFactory = () => new HttpClient(socketsHttpHandler, disposeHandler: false),
+                    SerializerOptions = new CosmosSerializationOptions
+                    {
+                        PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                    }
+                };
+
+                return new CosmosClient(cosmosDbConnectionString, cosmosClientOptions);
+            });
+
+            builder.Services.AddSingleton<ITodoManager, CosmosDbTodoManager>();
+        }
+    }
+}

--- a/samples/assistant/csharp-legacy/TodoManager.cs
+++ b/samples/assistant/csharp-legacy/TodoManager.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace AssistantSample;
+
+/// <summary>
+/// Todo item record which gets stored in the database.
+/// </summary>
+/// <param name="Id">A unique ID for the todo item.</param>
+/// <param name="Task">A description of the task.</param>
+public record TodoItem(string Id, string Task);
+
+/// <summary>
+/// Interface for managing todo items.
+/// </summary>
+public interface ITodoManager
+{
+    /// <summary>
+    /// Adds a new todo item to the database.
+    /// </summary>
+    Task AddTodoAsync(TodoItem todo);
+
+    /// <summary>
+    /// Gets all todo items from the database.
+    /// </summary>
+    Task<IReadOnlyList<TodoItem>> GetTodosAsync();
+}
+
+/// <summary>
+/// Implementation of <see cref="ITodoManager"/> which stores todo items in memory.
+/// </summary>
+/// <remarks>
+/// This implementation is designed to be used when running the function app locally.
+/// </remarks>
+class InMemoryTodoManager : ITodoManager
+{
+    readonly List<TodoItem> todos = new();
+
+    public Task AddTodoAsync(TodoItem todo)
+    {
+        this.todos.Add(todo);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<TodoItem>> GetTodosAsync()
+    {
+        return Task.FromResult<IReadOnlyList<TodoItem>>(this.todos.ToImmutableList());
+    }
+}
+
+/// <summary>
+/// Implementation of <see cref="ITodoManager"/> which stores todo items in Cosmos DB.
+/// </summary>
+/// <remarks>
+/// This implementation can be used in production or when running the function app locally.
+/// This implementation is also suitable for when the app needs to be scaled out or when
+/// the todos need to be persisted even after the function app is recycled.
+/// </remarks>
+class CosmosDbTodoManager : ITodoManager
+{
+    readonly ILogger logger;
+    readonly Container container;
+
+    public CosmosDbTodoManager(ILoggerFactory loggerFactory, CosmosClient cosmosClient)
+    {
+        if (loggerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        if (cosmosClient is null)
+        {
+            throw new ArgumentNullException(nameof(cosmosClient));
+        }
+
+        this.logger = loggerFactory.CreateLogger<CosmosDbTodoManager>();
+        this.container = cosmosClient.GetContainer("testdb", "my-todos");
+    }
+
+    public async Task AddTodoAsync(TodoItem todo)
+    {
+        this.logger.LogInformation("Adding todo ID = {Id} to container '{Container}'.", todo.Id, this.container.Id);
+        await this.container.CreateItemAsync(todo, new PartitionKey(todo.Id));
+    }
+
+    public async Task<IReadOnlyList<TodoItem>> GetTodosAsync()
+    {
+        this.logger.LogInformation("Getting all todos from container '{Container}'.", this.container.Id);
+        FeedIterator<TodoItem> query = this.container.GetItemQueryIterator<TodoItem>(
+            new QueryDefinition("SELECT * FROM c"));
+
+        List<TodoItem> results = new();
+        while (query.HasMoreResults)
+        {
+            FeedResponse<TodoItem> response = await query.ReadNextAsync();
+            results.AddRange(response.Resource);
+        }
+
+        this.logger.LogInformation("Found {Count} todos in container '{Container}'.", results.Count, this.container.Id);
+        return results;
+    }
+}

--- a/samples/assistant/csharp-legacy/host.json
+++ b/samples/assistant/csharp-legacy/host.json
@@ -1,0 +1,8 @@
+{
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI": "Information"
+    }
+  }
+}

--- a/samples/assistant/csharp-legacy/local.settings.json
+++ b/samples/assistant/csharp-legacy/local.settings.json
@@ -3,8 +3,10 @@
     "Values": {
       "AzureWebJobsStorage": "UseDevelopmentStorage=true",
       "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-      // NOTE: The below is a local CosmosDB Emulator connection string. The account key is NOT a real secret!
-      // IMPORTANT: This file is tracked by source control. Do not use a real secret here! Use environment variables instead to override these settings.
-      // "CosmosDbConnectionString": "AccountEndpoint=https://localhost:8081/;AccountKey={emulator-key-value}"
+      "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
+      "CosmosDatabaseName": "todoDB",
+      "CosmosContainerName": "myTasks",
+      "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
+      "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
     }
   }

--- a/samples/assistant/csharp-legacy/local.settings.json
+++ b/samples/assistant/csharp-legacy/local.settings.json
@@ -1,0 +1,10 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+      "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+      "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+      // NOTE: The below is a local CosmosDB Emulator connection string. The account key is NOT a real secret!
+      // IMPORTANT: This file is tracked by source control. Do not use a real secret here! Use environment variables instead to override these settings.
+      // "CosmosDbConnectionString": "AccountEndpoint=https://localhost:8081/;AccountKey={emulator-key-value}"
+    }
+  }

--- a/samples/assistant/csharp-ooproc/AssistantApis.cs
+++ b/samples/assistant/csharp-ooproc/AssistantApis.cs
@@ -64,7 +64,7 @@ static class AssistantApis
         string assistantId,
         [AssistantPostInput("{assistantId}", "{Query.message}", Model = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
     {
-        return new OkObjectResult(state.RecentMessages.LastOrDefault()?.Content ?? "No response returned.");
+        return new OkObjectResult(state.RecentMessages.Any() ? state.RecentMessages[state.RecentMessages.Count - 1].Content : "No response returned.");
     }
 
     /// <summary>

--- a/src/WebJobs.Extensions.OpenAI/Assistants/AssistantSkillTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/AssistantSkillTriggerAttribute.cs
@@ -5,7 +5,9 @@ using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenAI.Assistants;
 
-[Binding]
+#pragma warning disable CS0618 // Approved for use by this extension
+[Binding(TriggerHandlesReturnValue = true)]
+#pragma warning restore CS0618 // Type or member is obsolete
 [AttributeUsage(AttributeTargets.Parameter)]
 public sealed class AssistantSkillTriggerAttribute : Attribute
 {

--- a/src/WebJobs.Extensions.OpenAI/Assistants/IAssistantSkillInvoker.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/IAssistantSkillInvoker.cs
@@ -17,6 +17,20 @@ public interface IAssistantSkillInvoker
     Task<string?> InvokeAsync(ChatCompletionsFunctionToolCall call, CancellationToken cancellationToken);
 }
 
+class SkillInvocationContext
+{
+    public SkillInvocationContext(string arguments)
+    {
+        this.Arguments = arguments;
+    }
+
+    // The arguments are passed as a JSON object in the form of {"paramName":paramValue}
+    public string Arguments { get; }
+
+    // The result of the function invocation, if any
+    public object? Result { get; set; }
+}
+
 public class AssistantSkillManager : IAssistantSkillInvoker
 {
     record Skill(
@@ -144,30 +158,33 @@ public class AssistantSkillManager : IAssistantSkillInvoker
             throw new InvalidOperationException($"No skill registered with name '{call.Name}'");
         }
 
+        SkillInvocationContext skillInvocationContext = new(call.Arguments);
+
         // This call may throw if the Functions host is shutting down or if there is an internal error
         // in the Functions runtime. We don't currently try to handle these exceptions.
-        object? skillOutput = null;
         FunctionResult result = await skill.Executor.TryExecuteAsync(
             new TriggeredFunctionData
             {
-                TriggerValue = call.Arguments,
+                TriggerValue = skillInvocationContext,
 #pragma warning disable CS0618 // Approved for use by this extension
                 InvokeHandler = async userCodeInvoker =>
                 {
-                    // We yield control to ensure this code is executed asynchronously relative to WebJobs.
-                    // This ensures WebJobs is able to correctly cancel the invocation in the case of a timeout.
-                    await Task.Yield();
-
                     // Invoke the function and attempt to get the result.
                     this.logger.LogInformation("Invoking user-code function '{Name}'", call.Name);
                     Task invokeTask = userCodeInvoker.Invoke();
-                    if (invokeTask is not Task<object> resultTask)
+                    if (invokeTask is Task<object> invokeTaskWithResult)
                     {
-                        throw new InvalidOperationException(
-                            "The WebJobs runtime returned a invocation task that does not support return values!");
+                        skillInvocationContext.Result = await invokeTaskWithResult;
                     }
-
-                    skillOutput = await resultTask;
+                    else
+                    {
+                        // This is generally not expected to happen, but we handle it just in case.
+                        this.logger.LogWarning(
+                            "Unable to discover the return value (if any) for user-code function '{Name}'. " +
+                            "This is an internal error in the extension that may result in model hallucination.",
+                            call.Name);
+                        await invokeTask;
+                    }
                 }
 #pragma warning restore CS0618
             },
@@ -180,13 +197,13 @@ public class AssistantSkillManager : IAssistantSkillInvoker
             ExceptionDispatchInfo.Throw(result.Exception);
         }
 
-        if (skillOutput is null)
+        if (skillInvocationContext.Result is null)
         {
             return null;
         }
 
         // Convert the output to JSON
-        string jsonResult = JsonConvert.SerializeObject(skillOutput);
+        string jsonResult = JsonConvert.SerializeObject(skillInvocationContext.Result);
         this.logger.LogInformation(
             "Returning output of user-code function '{Name}' as JSON: {Json}", call.Name, jsonResult);
         return jsonResult;


### PR DESCRIPTION
### Issue description

Fixes issue where skill function return values were not being correctly passed to the LLM, resulting in hallucinations.

This was tricky to debug because 1) we rely on undocumented features of the WebJobs SDK to do custom skill invocations and 2) the OpenAI models are really good at hallucinating, making you think that the function calling worked when it really didn't.

### Change summary

There are two main changes:

1. Set `TriggerHandlesReturnValue` to `true` in the assistant skill trigger binding declaration.
2. Remove the `Task.Yield` from the function invocation code path.

The `Task.Yield` problem was found through trial and error. This was added originally because that's how custom function invocation is done in Durable Functions. However, this was causing race conditions in our OpenAI assistant trigger code, causing the extension to think the skill trigger execution completed when it hadn't (which was part of the reason the result was being lost). Only through trial-and-error did I figure this out. I assume `Task.Yield` works for Durable triggers and not for OpenAI skill triggers because of the different types of thread contexts used by these two extensions (in Durable, we rely on the Durable Task Framework which plays around with the thread context in ways that the OpenAI extension doesn't).

### Testing

I tested that function calling seems to work as expected with these changes in both C# out-of-proc and C# in-proc. I verified both in the debugger and in the extension logs.

### New sample

I also added an in-proc sample which I used for testing. I figured this might be useful to others who may want a simpler extension debugging experience. While we won't promote this, there may be a minority of users that would be interested in this as well. I called it `assistant-legacy` to make it clear that this is "legacy" and not the mainline supported scenario, which is ooproc.