### PR TITLE
CosmosDB Mongo vCore - Adding new vector index type - DiskANN

### DIFF
--- a/samples/rag-cosmosdb/README.md
+++ b/samples/rag-cosmosdb/README.md
@@ -53,7 +53,7 @@ Once you have an Cosmos DB resource, you can run the sample by following these s
 
    `NumLists` is the number of clusters that the inverted file (IVF) uses to group the vector data, as mentioned [here](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/vector-search#create-an-vector-index-using-ivf). By default, the number of clusters will be 1.
 
-   `Kind` is the Type of vector index to create. The options are vector-ivf and vector-hnsw. Note vector-ivf is available on all cluster tiers and vector-hnsw is available on M40 cluster tiers and higher.
+   `Kind` is the Type of vector index to create. The options are vector-ivf, vector-hnsw and vector-diskann. Note vector-ivf is available on all cluster tiers and vector-hnsw/vector-diskann is available on M40 cluster tiers and higher.
 
    `Similarity` is the Similarity metric to use with the index. Possible options are COS (cosine distance), L2 (Euclidean distance), and IP (inner product).
 
@@ -62,6 +62,12 @@ Once you have an Cosmos DB resource, you can run the sample by following these s
    `EfConstruction` is the size of the dynamic candidate list for constructing the graph (64 by default, minimum value is 4, maximum value is 1000). Higher efConstruction will result in better index quality and higher accuracy, but it will also increase the time required to build the index. efConstruction has to be at least 2 \* m
 
    `EfSearch` The size of the dynamic candidate list for search (40 by default). A higher value provides better recall at the cost of speed.
+
+   `MaxDegree` Maximum number of edges per node in the graph. This parameter ranges from 20 to 2048 (default is 32). Higher maxDegree is suitable for datasets with high dimensionality and/or high accuracy requirements.
+
+   `LBuild` Sets the number of candidate neighbors evaluated during DiskANN index construction. This parameter, which ranges from 10 to 500 (default is 50), balances accuracy and computational overhead: higher values improve index quality and accuracy but increase build time
+
+   `LSearch` Specifies the size of the dynamic candidate list for search. The default value is 40, with a configurable range from 10 to 1000. Increasing the value enhances recall but may reduce search speed.
 
 1. Use a terminal window to navigate to the sample directory
 
@@ -90,5 +96,6 @@ Mongo vCore has two vector index options:
 
 - vector-ivf (default value) : available on all cluster tiers.
 - vector-hnsw : available on M40 cluster tier and higher.
+- vector-diskann : available on M40 cluster tier and higher.
 
 Please read more about Vector Search in CosmosDB Mongo vCore [here](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,7 +36,7 @@
     <!-- Version for azure AI search webjobs and worker project -->
     <AzureAISearchVersion>0.4.0-alpha</AzureAISearchVersion>
     <!-- Version for CosmosDB search webjobs and worker project -->
-    <CosmosDBSearchVersion>0.3.0-alpha</CosmosDBSearchVersion>
+    <CosmosDBSearchVersion>0.4.0-alpha</CosmosDBSearchVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CHANGELOG.md
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.0 - Unreleased
+
+### Added
+
+- Added DiskANN support for CosmosDB (MongoDB) Search Provider. Refer [README](../../samples/rag-cosmosdb/README.md) for more information on usage.
+
 ## v0.3.0 - 2024/10/08
 
 ### Added
 
-- Added HNSW support for CosmosDB (MongoDB) Search Provider. Refer [README](../../samples/rag-cosmos-db/README.md) for more information on usage.
+- Added HNSW support for CosmosDB (MongoDB) Search Provider. Refer [README](../../samples/rag-cosmosdb/README.md) for more information on usage.
 
 ### Changed
 - Updated nuget dependencies
@@ -22,4 +28,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for CosmosDB (MongoDB) Search Provider. Refer [README](../../samples/rag-cosmos-db/README.md) for more information on usage.
+- Added support for CosmosDB (MongoDB) Search Provider. Refer [README](../../samples/rag-cosmosdb/README.md) for more information on usage.

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchConfigOptions.cs
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchConfigOptions.cs
@@ -34,6 +34,7 @@ public class CosmosDBSearchConfigOptions
     ///     Possible options are:
     ///         - vector-ivf
     ///         - vector-hnsw
+    ///         - vector-diskann
     /// </summary>
     public string Kind { get; set; } = "vector-ivf";
 
@@ -64,4 +65,22 @@ public class CosmosDBSearchConfigOptions
     /// the cost of speed.
     /// </summary>
     public int EfSearch { get; set; } = 40;
+
+    /// <summary>
+    /// Max number of neighbors. Only vector-diskann search supports this for now.
+    /// Default value is 32, range from 20 to 2048.
+    /// </summary>
+    public int MaxDegree { get; set; } = 32;
+
+    /// <summary>
+    /// l value for index building. Only vector-diskann search supports this for now.
+    /// Default value is 50, range from 10 to 500.
+    /// </summary>
+    public int LBuild { get; set; } = 50;
+
+    /// <summary>
+    /// l value for index searching. Only vector-diskann search supports this for now.
+    /// Default value is 40, range from 10 to 10000.
+    /// </summary>
+    public int LSearch { get; set; } = 40;
 }

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchProvider.cs
@@ -132,6 +132,9 @@ sealed class CosmosDBSearchProvider : ISearchProvider
                 case "vector-hnsw":
                     pipeline = this.GetVectorHNSWSearchPipeline(request);
                     break;
+                case "vector-diskann":
+                    pipeline = this.GetVectorDiskANNSearchPipeline(request);
+                    break;
             }
 
             IAsyncCursor<BsonDocument> cursor = await collection.AggregateAsync<BsonDocument>(
@@ -182,6 +185,9 @@ sealed class CosmosDBSearchProvider : ISearchProvider
                         break;
                     case "vector-hnsw":
                         vectorIndexDefinition = this.GetIndexDefinitionVectorHNSW();
+                        break;
+                    case "vector-diskann":
+                        vectorIndexDefinition = this.GetIndexDefinitionVectorDiskANN();
                         break;
                 }
 
@@ -344,6 +350,52 @@ sealed class CosmosDBSearchProvider : ISearchProvider
         return pipeline;
     }
 
+    BsonDocument[] GetVectorDiskANNSearchPipeline(SearchRequest request)
+    {
+        BsonDocument[] pipeline = new BsonDocument[]
+        {
+                new()
+                {
+                    {
+                        "$search",
+                        new BsonDocument
+                        {
+                            {
+                                "cosmosSearch",
+                                new BsonDocument
+                                {
+                                    {
+                                        "vector",
+                                        !(request.Embeddings.IsEmpty)
+                                            ? new BsonArray(request.Embeddings.ToArray())
+                                            : new BsonArray()
+                                    },
+                                    { "path", this.cosmosDBSearchConfigOptions.Value.EmbeddingKey },
+                                    { "k", request.MaxResults },
+                                    { "lSearch", this.cosmosDBSearchConfigOptions.Value.LSearch }
+                                }
+                            },
+                            { "returnStoredSource", true }
+                        }
+                    }
+                },
+                new()
+                {
+                    {
+                        "$project",
+                        new BsonDocument
+                        {
+                            { "embedding", 0 },
+                            { "_id", 0 },
+                            { "id", 0 },
+                            { "timestamp", 0 }
+                        }
+                    }
+                }
+        };
+        return pipeline;
+    }
+
     BsonDocument GetIndexDefinitionVectorIVF()
     {
         return new BsonDocument
@@ -429,4 +481,47 @@ sealed class CosmosDBSearchProvider : ISearchProvider
             }
         };
     }
+
+    BsonDocument GetIndexDefinitionVectorDiskANN()
+    {
+        return new BsonDocument
+        {
+            { "createIndexes", this.collectionName },
+            {
+                "indexes",
+                new BsonArray
+                {
+                    new BsonDocument
+                    {
+                        { "name", this.indexName },
+                        {
+                            "key",
+                            new BsonDocument
+                            {
+                                {
+                                    this.cosmosDBSearchConfigOptions.Value.EmbeddingKey,
+                                    "cosmosSearch"
+                                }
+                            }
+                        },
+                        {
+                            "cosmosSearchOptions",
+                            new BsonDocument
+                            {
+                                { "kind", this.cosmosDBSearchConfigOptions.Value.Kind },
+                                { "maxDegree", this.cosmosDBSearchConfigOptions.Value.MaxDegree },
+                                { "lBuild", this.cosmosDBSearchConfigOptions.Value.LBuild },
+                                { "similarity", this.cosmosDBSearchConfigOptions.Value.Similarity },
+                                {
+                                    "dimensions",
+                                    this.cosmosDBSearchConfigOptions.Value.VectorSearchDimensions
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
 }


### PR DESCRIPTION
Add a new vector index type DiskANN . 
Please read more about Vector Search in CosmosDB Mongo vCore and DiskANN [here](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search).