### PR TITLE
Ignore extra elements for CosmosDBSearchProvider

### DIFF
--- a/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchProvider.cs
@@ -25,6 +25,7 @@ sealed class CosmosDBSearchProvider : ISearchProvider
 
     public string Name { get; set; } = "CosmosDBSearch";
 
+    [BsonIgnoreExtraElements]
     internal class OutputDocument
     {
         public OutputDocument(string title, string text)


### PR DESCRIPTION
Fix the error by ignore extra elements:
```bash
[2025-03-20T21:27:10.928Z] System.Private.CoreLib: Exception while executing function: Functions.ask. MongoDB.Bson: Element '__cosmos_meta__' does not match any field or property of class Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch.CosmosDBSearchProvider+OutputDocument.
```