### PR TITLE
 Correct a typo in release pipeline packagePattern field for CosmosDBNoSqlSearch

### DIFF
--- a/eng/cd/official-release.yml
+++ b/eng/cd/official-release.yml
@@ -59,7 +59,7 @@ extends:
           stageName: CosmosDBNoSQLSearch
           displayName: Cosmos NoSQL Package
           artifactName: drop
-          packagePattern: '*.Extensions.OpenAI.CosmosDBSearch.$(CosmosDBNoSQLSearchVersion).nupkg'
+          packagePattern: '*.Extensions.OpenAI.CosmosDBNoSqlSearch.$(CosmosDBNoSQLSearchVersion).nupkg'
           blobPrefix: azure-functions/azure-functions-openai-extension-cosmosdbnosqlsearch/$(CosmosDBNoSQLSearchVersion)
 
       - template: templates/javapublish.yml


### PR DESCRIPTION
This pull request includes a minor fix to the `eng/cd/official-release.yml` file. The change corrects a typo in the `packagePattern` field by updating `CosmosDBSearch` to `CosmosDBNoSqlSearch` to ensure proper naming consistency.