### PR TITLE
update ps samples for search and store connection name properties, bump python requirements

### DIFF
--- a/samples/assistant/python/requirements.txt
+++ b/samples/assistant/python/requirements.txt
@@ -2,6 +2,6 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2
 azure-cosmos
 azure-identity

--- a/samples/chat/python/requirements.txt
+++ b/samples/chat/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2

--- a/samples/embeddings/python/requirements.txt
+++ b/samples/embeddings/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2

--- a/samples/rag-aisearch/powershell/IngestFile/function.json
+++ b/samples/rag-aisearch/powershell/IngestFile/function.json
@@ -20,7 +20,7 @@
       "direction": "out",
       "input": "{url}",
       "inputType": "Url",
-      "connectionName": "AISearchEndpoint",
+      "storeConnectionName": "AISearchEndpoint",
       "collection": "openai-index",
       "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
     }

--- a/samples/rag-aisearch/powershell/PromptFile/function.json
+++ b/samples/rag-aisearch/powershell/PromptFile/function.json
@@ -18,7 +18,7 @@
       "name": "SemanticSearchInput",
       "type": "semanticSearch",
       "direction": "in",
-      "connectionName": "AISearchEndpoint",
+      "searchConnectionName": "AISearchEndpoint",
       "collection": "openai-index",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/samples/rag-aisearch/python/requirements.txt
+++ b/samples/rag-aisearch/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2

--- a/samples/rag-cosmosdb-nosql/powershell/IngestFile/function.json
+++ b/samples/rag-cosmosdb-nosql/powershell/IngestFile/function.json
@@ -20,7 +20,7 @@
       "direction": "out",
       "input": "{url}",
       "inputType": "Url",
-      "connectionName": "CosmosDBNoSqlEndpoint",
+      "storeConnectionName": "CosmosDBNoSqlEndpoint",
       "collection": "openai-index",
       "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
     }

--- a/samples/rag-cosmosdb-nosql/powershell/PromptFile/function.json
+++ b/samples/rag-cosmosdb-nosql/powershell/PromptFile/function.json
@@ -18,7 +18,7 @@
       "name": "SemanticSearchInput",
       "type": "semanticSearch",
       "direction": "in",
-      "connectionName": "CosmosDBNoSqlEndpoint",
+      "searchConnectionName": "CosmosDBNoSqlEndpoint",
       "collection": "openai-index",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/samples/rag-cosmosdb-nosql/python/requirements.txt
+++ b/samples/rag-cosmosdb-nosql/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2

--- a/samples/rag-cosmosdb/powershell/IngestFile/function.json
+++ b/samples/rag-cosmosdb/powershell/IngestFile/function.json
@@ -20,7 +20,7 @@
       "direction": "out",
       "input": "{url}",
       "inputType": "Url",
-      "connectionName": "CosmosDBMongoVCoreConnectionString",
+      "storeConnectionName": "CosmosDBMongoVCoreConnectionString",
       "collection": "openai-index",
       "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
     }

--- a/samples/rag-cosmosdb/powershell/PromptFile/function.json
+++ b/samples/rag-cosmosdb/powershell/PromptFile/function.json
@@ -18,7 +18,7 @@
       "name": "SemanticSearchInput",
       "type": "semanticSearch",
       "direction": "in",
-      "connectionName": "CosmosDBMongoVCoreConnectionString",
+      "searchConnectionName": "CosmosDBMongoVCoreConnectionString",
       "collection": "openai-index",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/samples/rag-cosmosdb/python/requirements.txt
+++ b/samples/rag-cosmosdb/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2

--- a/samples/rag-kusto/powershell/IngestEmail/function.json
+++ b/samples/rag-kusto/powershell/IngestEmail/function.json
@@ -20,7 +20,7 @@
       "direction": "out",
       "input": "{url}",
       "inputType": "Url",
-      "connectionName": "KustoConnectionString",
+      "storeConnectionName": "KustoConnectionString",
       "collection": "Documents",
       "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
     }

--- a/samples/rag-kusto/powershell/PromptEmail/function.json
+++ b/samples/rag-kusto/powershell/PromptEmail/function.json
@@ -18,7 +18,7 @@
       "name": "SemanticSearchInput",
       "type": "semanticSearch",
       "direction": "in",
-      "connectionName": "KustoConnectionString",
+      "searchConnectionName": "KustoConnectionString",
       "collection": "Documents",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/samples/rag-kusto/python/requirements.txt
+++ b/samples/rag-kusto/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2

--- a/samples/textcompletion/python/requirements.txt
+++ b/samples/textcompletion/python/requirements.txt
@@ -2,4 +2,4 @@
 # The Python Worker is managed by Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
-azure-functions>=1.24.0b1
+azure-functions>=1.24.0b2


### PR DESCRIPTION
Resolves #173 

This pull request includes updates to PowerShell sample projects connection property naming standardization. Upgrades the `azure-functions` dependency across Python projects.

### Dependency Updates:
* Upgraded the `azure-functions` dependency from version `1.24.0b1` to `1.24.0b2` in the `requirements.txt` files of multiple Python sample projects, including `assistant`, `chat`, `embeddings`, `rag-aisearch`, `rag-cosmosdb-nosql`, `rag-cosmosdb`, `rag-kusto`, and `textcompletion`. [[1]](diffhunk://#diff-601b9fd8133051cc495c7327faca12a5d1b7ff7ce8f3917233f333de65352640L5-R5) [[2]](diffhunk://#diff-eb105d55e48da7074bfb2e920288fd3fb5619d8c2f530ec23b455b77dd36c64aL5-R5)

### Connection Property Renaming:
* Renamed the `connectionName` property to `searchConnectionName` in the `PromptFile/function.json` files of `rag-aisearch`, `rag-cosmosdb-nosql`, `rag-cosmosdb`, and `rag-kusto` projects to improve clarity and consistency. [[1]](diffhunk://#diff-e129a74f82968dd3185432fa5a5cd5cdfa28be758095ac165d36c619d292d250L21-R21) [[2]](diffhunk://#diff-26ddf8e7964b0d5fad8920c812a72d93ef6e0f9ba3a37df81fdd13536f070824L21-R21) [[3]](diffhunk://#diff-f972f25196fa51de928337af549d186ae343c1349711b5b0193e2ca3726f5f0aL21-R21) [[4]](diffhunk://#diff-4264fd4991bb62e58223cc76f9f365267de27bc1b75c03f742f25bcc2ac5ab62L21-R21)
* Renamed the `connectionName` property to `storeConnectionName` in the `IngestFile/function.json` files of `rag-cosmosdb-nosql`, `rag-cosmosdb`, and `rag-kusto` projects to align with standardized naming conventions. [[1]](diffhunk://#diff-6ac668a39d90a82812fa1f0c66310758290d3dc04495e421beabf9376d697ad6L23-R23) [[2]](diffhunk://#diff-3cfd4a19411e109d4faff39cec55f270676f9f4c08550b1a93f90d0dbffd9df0L23-R23) [[3]](diffhunk://#diff-0515bfc8a3a5f0454bd76a8d97520710b618e67bcc9f27d75329391eab6a507fL23-R23)