### PR TITLE
update the bundle specification in host json of python chat sample

### DIFF
--- a/samples/chat/python/host.json
+++ b/samples/chat/python/host.json
@@ -3,10 +3,10 @@
   "logging": {
     "logLevel": {
       "Microsoft.Azure.WebJobs.Extensions.OpenAI": "Information"
-    },
-    "extensionBundle": {
-      "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-      "version": "[4.*, 5.0.0)"
     }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+    "version": "[4.*, 5.0.0)"
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `host.json` file in the `samples/chat/python` directory. 
This moves out extension bundle specification out of logging block.