### PR TITLE
Disable ADO dependabot

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,4 @@
+# Mirrored repository. We use dependabot via GitHub, not Azure DevOps.
+version: 2
+enable-security-updates: false
+enable-campaigned-updates: false


### PR DESCRIPTION
Disabling ADO dependabot. Being a mirrored repo, we do not want automation opening PRs in ADO.