### PR TITLE
updates for default azure credential and azure identity package

### DIFF
--- a/samples/assistant/java/pom.xml
+++ b/samples/assistant/java/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.16.2</version>
+            <version>1.18.0</version>
         </dependency>
 
     </dependencies>

--- a/src/WebJobs.Extensions.OpenAI.AzureAISearch/AzureAISearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.AzureAISearch/AzureAISearchProvider.cs
@@ -49,6 +49,19 @@ sealed class AzureAISearchProvider : ISearchProvider
     /// <exception cref="ArgumentNullException">Throws ArgumentNullException if logger factory is null.</exception>
     public AzureAISearchProvider(IConfiguration configuration, ILoggerFactory loggerFactory, IOptions<AzureAISearchConfigOptions> azureAiSearchConfigOptions, AzureComponentFactory azureComponentFactory)
     {
+
+#if RELEASE
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS")))
+        {
+            Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "prod");
+        }
+#else
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS")))
+        {
+            Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "dev");
+        }
+
+#endif
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         this.azureComponentFactory = azureComponentFactory ?? throw new ArgumentNullException(nameof(azureComponentFactory));
 
@@ -331,7 +344,7 @@ sealed class AzureAISearchProvider : ISearchProvider
     TokenCredential GetSearchTokenCredential() =>
         this.searchConnectionConfigSection.Exists()
             ? this.azureComponentFactory.CreateTokenCredential(this.searchConnectionConfigSection)
-            : new DefaultAzureCredential();
+            : new DefaultAzureCredential(DefaultAzureCredential.DefaultEnvironmentVariableName);
 
     void SetConfigSectionProperties()
     {

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch/CosmosDBNoSqlSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch/CosmosDBNoSqlSearchProvider.cs
@@ -44,6 +44,19 @@ sealed class CosmosDBNoSqlSearchProvider : ISearchProvider
         AzureComponentFactory azureComponentFactory
     )
     {
+
+#if RELEASE
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS")))
+        {
+            Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "prod");
+        }
+#else
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS")))
+        {
+            Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "dev");
+        }
+#endif
+
         this.configuration =
             configuration ?? throw new ArgumentNullException(nameof(configuration));
         this.azureComponentFactory =
@@ -238,7 +251,7 @@ sealed class CosmosDBNoSqlSearchProvider : ISearchProvider
 
             return new CosmosClient(
                 connectionSettingValue, // This is the endpoint URI
-                new DefaultAzureCredential(),
+                new DefaultAzureCredential(DefaultAzureCredential.DefaultEnvironmentVariableName),
                 cosmosClientOptions
             );
         }

--- a/src/WebJobs.Extensions.OpenAI/OpenAIClientFactory.cs
+++ b/src/WebJobs.Extensions.OpenAI/OpenAIClientFactory.cs
@@ -31,6 +31,19 @@ public class OpenAIClientFactory
         AzureComponentFactory azureComponentFactory,
         ILoggerFactory loggerFactory)
     {
+
+#if RELEASE
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS")))
+        {
+            Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "prod");
+        }
+#else
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS")))
+        {
+            Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "dev");
+        }
+#endif
+
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         this.azureComponentFactory = azureComponentFactory ?? throw new ArgumentNullException(nameof(azureComponentFactory));
         this.logger = loggerFactory?.CreateLogger<OpenAIClientFactory>() ?? throw new ArgumentNullException(nameof(loggerFactory));
@@ -118,7 +131,7 @@ public class OpenAIClientFactory
 
                 TokenCredential tokenCredential = section.Exists() ?
                     this.azureComponentFactory.CreateTokenCredential(section) :
-                    new DefaultAzureCredential();
+                    new DefaultAzureCredential(DefaultAzureCredential.DefaultEnvironmentVariableName);
                 return this.CreateAzureOpenAIClientWithTokenCredential(this.aiEndpoint, tokenCredential);
             }
         }

--- a/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
+++ b/src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.10.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.10.0" />


### PR DESCRIPTION
This pull request updates the Azure identity dependencies and standardizes the way Azure token credentials are set and used across the codebase. The main focus is on ensuring that the `AZURE_TOKEN_CREDENTIALS` environment variable is set appropriately for different build environments (development vs. production), and that the correct overload of `DefaultAzureCredential` is used. These changes improve consistency and reliability in how Azure credentials are managed.

**Dependency version updates:**

* Upgraded the `Azure.Identity` dependency in both `samples/assistant/java/pom.xml` (from 1.16.2 to 1.18.0) and `src/WebJobs.Extensions.OpenAI/WebJobs.Extensions.OpenAI.csproj` (from 1.13.2 to 1.17.1) for improved security and compatibility. [[1]](diffhunk://#diff-f591ab8c9718b680a8fae2b35bbfdb9f61d3ebe82d1e45497bf28b38168dc999L50-R50) [[2]](diffhunk://#diff-b294a14bba7fbb381752db795a69daa97e8358870ae8fc70ba71c12cc7f89ea1L10-R10)

**Environment variable handling for credentials:**

* Added logic in constructors of `AzureAISearchProvider`, `CosmosDBNoSqlSearchProvider`, and `OpenAIClientFactory` to set the `AZURE_TOKEN_CREDENTIALS` environment variable to `'prod'` in release builds and `'dev'` in non-release builds if it is not already set. This ensures the correct environment is used for authentication. [[1]](diffhunk://#diff-e8ab4c35c082d54a19198a03f52bd4ab51cf48a2b1baedd9b1b30973b5e97362R52-R64) [[2]](diffhunk://#diff-63567056dc4f27096ed8db486bf916fd151a7bcb9a6e0ce407abfcd09470c57cR47-R59) [[3]](diffhunk://#diff-1fc51c09e29ec961e0777ed95cda5529dd8d407c215337c4c0897d44dfd12e34R34-R46)

**Credential instantiation consistency:**

* Updated instantiations of `DefaultAzureCredential` in all relevant providers and client factories to use the `DefaultEnvironmentVariableName` overload, aligning with the new environment variable logic and ensuring consistent credential sourcing. [[1]](diffhunk://#diff-e8ab4c35c082d54a19198a03f52bd4ab51cf48a2b1baedd9b1b30973b5e97362L334-R347) [[2]](diffhunk://#diff-63567056dc4f27096ed8db486bf916fd151a7bcb9a6e0ce407abfcd09470c57cL241-R254) [[3]](diffhunk://#diff-1fc51c09e29ec961e0777ed95cda5529dd8d407c215337c4c0897d44dfd12e34L121-R134)
