### PR TITLE
Fix: allow updating assistant instructions without resetting chat history

### DIFF
--- a/java-library/src/main/java/com/microsoft/azure/functions/openai/annotation/assistant/AssistantCreateRequest.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/openai/annotation/assistant/AssistantCreateRequest.java
@@ -15,6 +15,7 @@ public class AssistantCreateRequest {
     private String instructions = "You are a helpful assistant.";
     private String chatStorageConnectionSetting;
     private String collectionName = "ChatState";
+    private boolean preserveChatHistory;
 
     public AssistantCreateRequest(String id) {
         this.id = id;
@@ -105,5 +106,23 @@ public class AssistantCreateRequest {
      */
     public void setCollectionName(String collectionName) {
         this.collectionName = collectionName;
+    }
+
+    /**
+     * Gets whether existing chat history should be preserved when updating instructions.
+     *
+     * @return True to preserve chat history; otherwise false.
+     */
+    public boolean isPreserveChatHistory() {
+        return preserveChatHistory;
+    }
+
+    /**
+     * Sets whether existing chat history should be preserved when updating instructions.
+     *
+     * @param preserveChatHistory True to preserve chat history; otherwise false.
+     */
+    public void setPreserveChatHistory(boolean preserveChatHistory) {
+        this.preserveChatHistory = preserveChatHistory;
     }
 }

--- a/samples/assistant/README.md
+++ b/samples/assistant/README.md
@@ -235,6 +235,18 @@ For additional details on using identity-based connections, refer to the [Azure 
     PUT http://localhost:7168/api/assistants/assistant123
     ```
 
+    You can optionally provide a JSON body to set or update the assistant instructions. By default, the assistant is reset on creation. To preserve existing chat history and only update the system instructions for an existing assistant, set `preserveChatHistory` to `true`.
+
+    ```http
+    PUT http://localhost:7168/api/assistants/assistant123
+    Content-Type: application/json
+
+    {
+      "instructions": "You are a concise assistant.",
+      "preserveChatHistory": true
+    }
+    ```
+
     > **NOTE:** The `assistant123` value is the unique ID of the assistant. You can use any value you like, but it must be unique and must be used consistently in all subsequent requests.
 
     > **NOTE:** All the HTTP requests in this sample can also be found in the [demo.http](demo.http) file, which can be opened and run in most IDEs.

--- a/samples/assistant/demo.http
+++ b/samples/assistant/demo.http
@@ -2,6 +2,16 @@
 PUT http://localhost:7071/api/assistants/assistant123
 
 
+### Update instructions without resetting chat history
+PUT http://localhost:7071/api/assistants/assistant123
+Content-Type: application/json
+
+{
+	"instructions": "You are a concise assistant.",
+	"preserveChatHistory": true
+}
+
+
 ### Reminder #1 - Remind me to call my dad
 POST http://localhost:7071/api/assistants/assistant123?message=Remind%20me%20to%20call%20my%20dad
 

--- a/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
+++ b/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
@@ -80,8 +80,16 @@ public class AssistantApis {
                 assistantCreateRequest.getClass()
                     .getMethod("setPreserveChatHistory", boolean.class)
                     .invoke(assistantCreateRequest, preserveChatHistory);
-            } catch (Exception ex) {
-                context.getLogger().warning("PreserveChatHistory not supported by current SDK version.");
+            } catch (NoSuchMethodException ex) {
+                // Older SDK version that does not support preserveChatHistory; continue without it.
+                context.getLogger().warning(
+                    "PreserveChatHistory not supported by current SDK version (method setPreserveChatHistory not found): "
+                        + ex.getMessage());
+            } catch (ReflectiveOperationException ex) {
+                // Method exists but could not be invoked due to a reflection error.
+                context.getLogger().warning(
+                    "Failed to invoke setPreserveChatHistory via reflection: "
+                        + ex.getClass().getSimpleName() + ": " + ex.getMessage());
             }
 
             message.setValue(assistantCreateRequest);

--- a/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
+++ b/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
@@ -61,10 +61,28 @@ public class AssistantApis {
             
             String instructions = "Don't make assumptions about what values to plug into functions.\n" +
                     "Ask for clarification if a user request is ambiguous.";
+            boolean preserveChatHistory = false;
+
+            if (request.getBody().isPresent()) {
+                JSONObject body = new JSONObject(request.getBody().get());
+                if (body.has("instructions")) {
+                    instructions = body.getString("instructions");
+                }
+                if (body.has("preserveChatHistory")) {
+                    preserveChatHistory = body.getBoolean("preserveChatHistory");
+                }
+            }
 
             AssistantCreateRequest assistantCreateRequest = new AssistantCreateRequest(assistantId, instructions);
             assistantCreateRequest.setChatStorageConnectionSetting(DEFAULT_CHATSTORAGE);
             assistantCreateRequest.setCollectionName(DEFAULT_COLLECTION);
+            try {
+                assistantCreateRequest.getClass()
+                    .getMethod("setPreserveChatHistory", boolean.class)
+                    .invoke(assistantCreateRequest, preserveChatHistory);
+            } catch (Exception ex) {
+                context.getLogger().warning("PreserveChatHistory not supported by current SDK version.");
+            }
 
             message.setValue(assistantCreateRequest);
             JSONObject response = new JSONObject();

--- a/samples/assistant/javascript/src/functions/assistantApis.js
+++ b/samples/assistant/javascript/src/functions/assistantApis.js
@@ -16,16 +16,24 @@ app.http('CreateAssistant', {
     extraOutputs: [chatBotCreateOutput],
     handler: async (request, context) => {
         const assistantId = request.params.assistantId
+        let inputJson = {}
+        try {
+            inputJson = await request.json()
+        } catch {
+            inputJson = {}
+        }
         const instructions =
             `
             Don't make assumptions about what values to plug into functions.
             Ask for clarification if a user request is ambiguous.
             `
+        const requestInstructions = inputJson.instructions ?? instructions
         const createRequest = {
             id: assistantId,
-            instructions: instructions,
+            instructions: requestInstructions,
             chatStorageConnectionSetting: CHAT_STORAGE_CONNECTION_SETTING,
-            collectionName: COLLECTION_NAME
+            collectionName: COLLECTION_NAME,
+            preserveChatHistory: inputJson.preserveChatHistory === true
         }
         context.extraOutputs.set(chatBotCreateOutput, createRequest)
         return { status: 202, jsonBody: { assistantId: assistantId } }

--- a/samples/assistant/python/assistant_apis.py
+++ b/samples/assistant/python/assistant_apis.py
@@ -14,15 +14,23 @@ def create_assistant(
     req: func.HttpRequest, requests: func.Out[str]
 ) -> func.HttpResponse:
     assistantId = req.route_params.get("assistantId")
+    body = {}
+    try:
+        body = req.get_json()
+    except ValueError:
+        body = {}
     instructions = """
             Don't make assumptions about what values to plug into functions.
             Ask for clarification if a user request is ambiguous.
             """
+    request_instructions = body.get("instructions", instructions)
+    preserve_chat_history = bool(body.get("preserveChatHistory", False))
     create_request = {
         "id": assistantId,
-        "instructions": instructions,
+        "instructions": request_instructions,
         "chatStorageConnectionSetting": DEFAULT_CHAT_STORAGE_SETTING,
         "collectionName": DEFAULT_CHAT_COLLECTION_NAME,
+        "preserveChatHistory": preserve_chat_history,
     }
     requests.set(json.dumps(create_request))
     response_json = {"assistantId": assistantId}

--- a/samples/assistant/typescript/src/functions/assistantApis.ts
+++ b/samples/assistant/typescript/src/functions/assistantApis.ts
@@ -16,16 +16,24 @@ app.http('CreateAssistant', {
     extraOutputs: [chatBotCreateOutput],
     handler: async (request: HttpRequest, context: InvocationContext) => {
         const assistantId = request.params.assistantId
+        let inputJson: any = {}
+        try {
+            inputJson = await request.json()
+        } catch {
+            inputJson = {}
+        }
         const instructions =
             `
             Don't make assumptions about what values to plug into functions.
             Ask for clarification if a user request is ambiguous.
             `
+        const requestInstructions = inputJson.instructions ?? instructions
         const createRequest = {
             id: assistantId,
-            instructions: instructions,
+            instructions: requestInstructions,
             chatStorageConnectionSetting: CHAT_STORAGE_CONNECTION_SETTING,
-            collectionName: COLLECTION_NAME
+            collectionName: COLLECTION_NAME,
+            preserveChatHistory: inputJson.preserveChatHistory === true
         }
         context.extraOutputs.set(chatBotCreateOutput, createRequest)
         return { status: 202, jsonBody: { assistantId: assistantId } }

--- a/src/Functions.Worker.Extensions.OpenAI/Assistants/AssistantCreateRequest.cs
+++ b/src/Functions.Worker.Extensions.OpenAI/Assistants/AssistantCreateRequest.cs
@@ -48,4 +48,9 @@ public class AssistantCreateRequest
     /// Table collection name for chat storage.
     /// </summary>
     public string CollectionName { get; set; } = "ChatState";
+
+    /// <summary>
+    /// When true, preserves existing chat history and only updates the system instructions.
+    /// </summary>
+    public bool PreserveChatHistory { get; set; }
 }

--- a/src/WebJobs.Extensions.OpenAI/Assistants/AssistantCreateAttribute.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/AssistantCreateAttribute.cs
@@ -69,4 +69,9 @@ public class AssistantCreateRequest
     /// Table collection name for chat storage.
     /// </summary>
     public string CollectionName { get; set; } = "ChatState";
+
+    /// <summary>
+    /// When true, preserves existing chat history and only updates the system instructions.
+    /// </summary>
+    public bool PreserveChatHistory { get; set; }
 }

--- a/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
@@ -260,7 +260,7 @@ class DefaultAssistantService : IAssistantService
 
             ChatMessageTableEntity newSystemMessage = new(
                 partitionKey: request.Id,
-                messageIndex: 0,
+                messageIndex: chatState.Metadata.TotalMessages + 1,
                 content: request.Instructions,
                 role: ChatMessageRole.System,
                 toolCalls: null);

--- a/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
@@ -247,6 +247,9 @@ class DefaultAssistantService : IAssistantService
         {
             systemMessage.Content = request.Instructions;
             systemMessage.CreatedAt = DateTime.UtcNow;
+            this.logger.LogInformation(
+                "[{Id}] Existing system message found. Updating system instructions.",
+                request.Id);
             batch.Add(new TableTransactionAction(TableTransactionActionType.UpdateMerge, systemMessage));
         }
         else

--- a/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
@@ -257,7 +257,7 @@ class DefaultAssistantService : IAssistantService
 
             ChatMessageTableEntity newSystemMessage = new(
                 partitionKey: request.Id,
-                messageIndex: chatState.Metadata.TotalMessages + 1,
+                messageIndex: 0,
                 content: request.Instructions,
                 role: ChatMessageRole.System,
                 toolCalls: null);

--- a/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
@@ -68,68 +68,21 @@ class DefaultAssistantService : IAssistantService
         // Create the table if it doesn't exist
         await tableClient.CreateIfNotExistsAsync();
 
-        // Check to see if the assistant has already been initialized
-        AsyncPageable<TableEntity> queryResultsFilter = tableClient.QueryAsync<TableEntity>(
-            filter: $"PartitionKey eq '{request.Id}'",
-            cancellationToken: cancellationToken);
-
-        // Create a batch of table transaction actions for deleting entities
-        List<TableTransactionAction> deleteBatch = new(capacity: 100);
-
-        // Local function for deleting batches of assistant state
-        async Task DeleteBatch()
+        if (request.PreserveChatHistory)
         {
-            if (deleteBatch.Count > 0)
+            InternalChatState? existingState = await this.LoadChatStateAsync(request.Id, tableClient, cancellationToken);
+            if (existingState is not null && existingState.Metadata.Exists)
             {
-                this.logger.LogInformation(
-                    "Deleting {Count} record(s) for assistant '{Id}'.",
-                    deleteBatch.Count,
-                    request.Id);
-                await tableClient.SubmitTransactionAsync(deleteBatch);
-                deleteBatch.Clear();
+                await this.UpdateAssistantInstructionsAsync(request, existingState, tableClient, cancellationToken);
+                return;
             }
         }
-
-        await foreach (TableEntity entity in queryResultsFilter)
+        else
         {
-            // If the count is greater than or equal to 100, submit the transaction and clear the batch
-            if (deleteBatch.Count >= 100)
-            {
-                await DeleteBatch();
-            }
-
-            deleteBatch.Add(new TableTransactionAction(TableTransactionActionType.Delete, entity));
+            await this.DeleteAssistantStateAsync(request.Id, tableClient, cancellationToken);
         }
 
-        if (deleteBatch.Any())
-        {
-            // delete any remaining
-            await DeleteBatch();
-        }
-
-        // Create a batch of table transaction actions
-        List<TableTransactionAction> batch = new();
-
-        // Add first chat message entity to table
-        if (!string.IsNullOrWhiteSpace(request.Instructions))
-        {
-            ChatMessageTableEntity chatMessageEntity = new(
-                partitionKey: request.Id,
-                messageIndex: 1, // 1-based index
-                content: request.Instructions,
-                role: ChatMessageRole.System,
-                toolCalls: null);
-
-            batch.Add(new TableTransactionAction(TableTransactionActionType.Add, chatMessageEntity));
-        }
-
-        // Add assistant state entity to table
-        AssistantStateEntity assistantStateEntity = new(request.Id) { TotalMessages = batch.Count };
-
-        batch.Add(new TableTransactionAction(TableTransactionActionType.Add, assistantStateEntity));
-
-        // Add the batch of table transaction actions to the table
-        await tableClient.SubmitTransactionAsync(batch);
+        await this.CreateAssistantEntitiesAsync(request, tableClient, cancellationToken);
     }
 
     public async Task<AssistantState> GetStateAsync(AssistantQueryAttribute assistantQuery, CancellationToken cancellationToken)
@@ -209,6 +162,116 @@ class DefaultAssistantService : IAssistantService
     }
 
     // Helper methods
+    async Task DeleteAssistantStateAsync(string assistantId, TableClient tableClient, CancellationToken cancellationToken)
+    {
+        AsyncPageable<TableEntity> queryResultsFilter = tableClient.QueryAsync<TableEntity>(
+            filter: $"PartitionKey eq '{assistantId}'",
+            cancellationToken: cancellationToken);
+
+        List<TableTransactionAction> deleteBatch = new(capacity: 100);
+
+        async Task DeleteBatch()
+        {
+            if (deleteBatch.Count > 0)
+            {
+                this.logger.LogInformation(
+                    "Deleting {Count} record(s) for assistant '{Id}'.",
+                    deleteBatch.Count,
+                    assistantId);
+                await tableClient.SubmitTransactionAsync(deleteBatch, cancellationToken);
+                deleteBatch.Clear();
+            }
+        }
+
+        await foreach (TableEntity entity in queryResultsFilter)
+        {
+            if (deleteBatch.Count >= 100)
+            {
+                await DeleteBatch();
+            }
+
+            deleteBatch.Add(new TableTransactionAction(TableTransactionActionType.Delete, entity));
+        }
+
+        if (deleteBatch.Any())
+        {
+            await DeleteBatch();
+        }
+    }
+
+    async Task CreateAssistantEntitiesAsync(AssistantCreateRequest request, TableClient tableClient, CancellationToken cancellationToken)
+    {
+        List<TableTransactionAction> batch = new();
+
+        if (!string.IsNullOrWhiteSpace(request.Instructions))
+        {
+            ChatMessageTableEntity chatMessageEntity = new(
+                partitionKey: request.Id,
+                messageIndex: 1, // 1-based index
+                content: request.Instructions,
+                role: ChatMessageRole.System,
+                toolCalls: null);
+
+            batch.Add(new TableTransactionAction(TableTransactionActionType.Add, chatMessageEntity));
+        }
+
+        AssistantStateEntity assistantStateEntity = new(request.Id) { TotalMessages = batch.Count };
+
+        batch.Add(new TableTransactionAction(TableTransactionActionType.Add, assistantStateEntity));
+
+        await tableClient.SubmitTransactionAsync(batch, cancellationToken);
+    }
+
+    async Task UpdateAssistantInstructionsAsync(
+        AssistantCreateRequest request,
+        InternalChatState chatState,
+        TableClient tableClient,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Instructions))
+        {
+            this.logger.LogInformation(
+                "[{Id}] PreserveChatHistory requested without new instructions. No changes applied.",
+                request.Id);
+            return;
+        }
+
+        ChatMessageTableEntity? systemMessage = chatState.Messages
+            .Where(msg => string.Equals(msg.Role, ChatMessageRole.System.ToString(), StringComparison.OrdinalIgnoreCase))
+            .OrderBy(msg => msg.RowKey, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+
+        List<TableTransactionAction> batch = new();
+
+        if (systemMessage is not null)
+        {
+            systemMessage.Content = request.Instructions;
+            systemMessage.CreatedAt = DateTime.UtcNow;
+            batch.Add(new TableTransactionAction(TableTransactionActionType.UpdateMerge, systemMessage));
+        }
+        else
+        {
+            this.logger.LogWarning(
+                "[{Id}] No existing system message found. Appending new system instructions.",
+                request.Id);
+
+            ChatMessageTableEntity newSystemMessage = new(
+                partitionKey: request.Id,
+                messageIndex: chatState.Metadata.TotalMessages + 1,
+                content: request.Instructions,
+                role: ChatMessageRole.System,
+                toolCalls: null);
+
+            chatState.Messages.Add(newSystemMessage);
+            chatState.Metadata.TotalMessages++;
+            batch.Add(new TableTransactionAction(TableTransactionActionType.Add, newSystemMessage));
+        }
+
+        chatState.Metadata.LastUpdatedAt = DateTime.UtcNow;
+        batch.Add(new TableTransactionAction(TableTransactionActionType.UpdateMerge, chatState.Metadata));
+
+        await tableClient.SubmitTransactionAsync(batch, cancellationToken);
+    }
     void ValidateAttributes(AssistantPostAttribute attribute)
     {
         if (string.IsNullOrEmpty(attribute.Id))

--- a/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
+++ b/src/WebJobs.Extensions.OpenAI/Assistants/AssistantService.cs
@@ -246,7 +246,6 @@ class DefaultAssistantService : IAssistantService
         if (systemMessage is not null)
         {
             systemMessage.Content = request.Instructions;
-            systemMessage.CreatedAt = DateTime.UtcNow;
             this.logger.LogInformation(
                 "[{Id}] Existing system message found. Updating system instructions.",
                 request.Id);


### PR DESCRIPTION
Summary
This PR fixes the Azure Functions OpenAI extension so assistant instructions can be updated without resetting the existing chat history.

Problem
Currently, changing the assistant instructions causes the extension to reset or reinitialise the conversation state, which discards chat history and breaks common scenarios where instructions need to evolve mid-session (eg dynamic system prompts, user preferences, moderation policy updates).

Change
	•	Preserve existing chat history when assistant instructions change
	•	Update the assistant configuration/instructions independently of the conversation history
	•	Keep existing behaviour for creating a new conversation unchanged

Testing
	•	Created and ran unit tests in AssistantServiceTests
	•	Verified locally using sample Function: update instructions mid-conversation and confirm subsequent responses follow the new instructions while earlier messages remain in context
