### PR TITLE
﻿Upgrade CosmosDB SDK packages - MongoDB.Driver 3.7.1, Microsoft.Azure.Cosmos 3.58.0

### DIFF
--- a/samples/rag-cosmosdb-nosql/csharp-ooproc/CosmosDBNoSqlSearch.csproj
+++ b/samples/rag-cosmosdb-nosql/csharp-ooproc/CosmosDBNoSqlSearch.csproj
@@ -7,12 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Functions.Worker.Extensions.OpenAI\Functions.Worker.Extensions.OpenAI.csproj" />

--- a/samples/rag-cosmosdb-nosql/csharp-ooproc/FilePrompt.cs
+++ b/samples/rag-cosmosdb-nosql/csharp-ooproc/FilePrompt.cs
@@ -66,6 +66,7 @@ public static class FilePrompt
         )]
         public required SearchableDocument SearchableDocument { get; init; }
 
+        [HttpResult]
         public IActionResult? HttpResponse { get; set; }
     }
 

--- a/samples/rag-cosmosdb-nosql/java/pom.xml
+++ b/samples/rag-cosmosdb-nosql/java/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <azure.functions.maven.plugin.version>1.38.0</azure.functions.maven.plugin.version>
-        <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
+        <azure.functions.maven.plugin.version>1.41.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>3.2.4</azure.functions.java.library.version>
         <azure-functions-java-library-openai>0.5.0-preview</azure-functions-java-library-openai>
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>

--- a/samples/rag-cosmosdb-nosql/java/pom.xml
+++ b/samples/rag-cosmosdb-nosql/java/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <azure.functions.maven.plugin.version>1.29.0</azure.functions.maven.plugin.version>
+        <azure.functions.maven.plugin.version>1.38.0</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
         <azure-functions-java-library-openai>0.5.0-preview</azure-functions-java-library-openai>
         <functionAppName>azfs-java-openai-sample</functionAppName>

--- a/samples/rag-cosmosdb-nosql/javascript/src/app.js
+++ b/samples/rag-cosmosdb-nosql/javascript/src/app.js
@@ -6,7 +6,7 @@ const embeddingsStoreOutput = output.generic({
     type: "embeddingsStore",
     input: "{url}", 
     inputType: "url", 
-    connectionName: "CosmosDBNoSqlEndpoint", 
+    storeConnectionName: "CosmosDBNoSqlEndpoint", 
     collection: "openai-index", 
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
@@ -38,7 +38,7 @@ app.http('IngestFile', {
 
 const semanticSearchInput = input.generic({
     type: "semanticSearch",
-    connectionName: "CosmosDBNoSqlEndpoint",
+    searchConnectionName: "CosmosDBNoSqlEndpoint",
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/samples/rag-cosmosdb-nosql/typescript/package-lock.json
+++ b/samples/rag-cosmosdb-nosql/typescript/package-lock.json
@@ -736,7 +736,7 @@
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       }
     },
     "minipass": {

--- a/samples/rag-cosmosdb-nosql/typescript/package-lock.json
+++ b/samples/rag-cosmosdb-nosql/typescript/package-lock.json
@@ -11,7 +11,7 @@
         "@azure/functions": "^4.11.0"
       },
       "devDependencies": {
-        "@types/node": "^18.x",
+        "@types/node": "^22.x",
         "rimraf": "^5.0.0",
         "typescript": "^4.0.0"
       }
@@ -65,10 +65,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz",
-      "integrity": "sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ==",
-      "dev": true
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -453,6 +457,13 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -598,10 +609,13 @@
       "optional": true
     },
     "@types/node": {
-      "version": "18.15.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz",
-      "integrity": "sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ==",
-      "dev": true
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "ansi-regex": {
       "version": "6.2.2",
@@ -872,6 +886,12 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "which": {

--- a/samples/rag-cosmosdb-nosql/typescript/package.json
+++ b/samples/rag-cosmosdb-nosql/typescript/package.json
@@ -13,7 +13,7 @@
     "@azure/functions": "^4.11.0"
   },
   "devDependencies": {
-    "@types/node": "^18.x",
+    "@types/node": "^22.x",
     "rimraf": "^5.0.0",
     "typescript": "^4.0.0"
   },

--- a/samples/rag-cosmosdb-nosql/typescript/src/app.ts
+++ b/samples/rag-cosmosdb-nosql/typescript/src/app.ts
@@ -9,7 +9,7 @@ const embeddingsStoreOutput = output.generic({
     type: "embeddingsStore",
     input: "{url}", 
     inputType: "url", 
-    connectionName: "CosmosDBNoSqlEndpoint", 
+    storeConnectionName: "CosmosDBNoSqlEndpoint", 
     collection: "openai-index", 
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
@@ -41,7 +41,7 @@ app.http('IngestFile', {
 
 const semanticSearchInput = input.generic({
     type: "semanticSearch",
-    connectionName: "CosmosDBNoSqlEndpoint",
+    searchConnectionName: "CosmosDBNoSqlEndpoint",
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/samples/rag-cosmosdb/csharp-ooproc/FilePrompt.cs
+++ b/samples/rag-cosmosdb/csharp-ooproc/FilePrompt.cs
@@ -69,6 +69,7 @@ public static class FilePrompt
         [EmbeddingsStoreOutput("{url}", InputType.Url, "CosmosDBMongoVCoreConnectionString", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
         public required SearchableDocument SearchableDocument { get; init; }
 
+        [HttpResult]
         public IActionResult? HttpResponse { get; set; }
     }
 

--- a/samples/rag-cosmosdb/csharp-ooproc/SemanticCosmosDBSearchEmbeddings.csproj
+++ b/samples/rag-cosmosdb/csharp-ooproc/SemanticCosmosDBSearchEmbeddings.csproj
@@ -7,12 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Functions.Worker.Extensions.OpenAI\Functions.Worker.Extensions.OpenAI.csproj" />

--- a/samples/rag-cosmosdb/java/pom.xml
+++ b/samples/rag-cosmosdb/java/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <azure.functions.maven.plugin.version>1.38.0</azure.functions.maven.plugin.version>
-        <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
+        <azure.functions.maven.plugin.version>1.41.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>3.2.4</azure.functions.java.library.version>
         <azure-functions-java-library-openai>0.5.0-preview</azure-functions-java-library-openai>
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>

--- a/samples/rag-cosmosdb/java/pom.xml
+++ b/samples/rag-cosmosdb/java/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <azure.functions.maven.plugin.version>1.29.0</azure.functions.maven.plugin.version>
+        <azure.functions.maven.plugin.version>1.38.0</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
         <azure-functions-java-library-openai>0.5.0-preview</azure-functions-java-library-openai>
         <functionAppName>azfs-java-openai-sample</functionAppName>

--- a/samples/rag-cosmosdb/javascript/src/app.js
+++ b/samples/rag-cosmosdb/javascript/src/app.js
@@ -6,7 +6,7 @@ const embeddingsStoreOutput = output.generic({
     type: "embeddingsStore",
     input: "{url}", 
     inputType: "url", 
-    connectionName: "CosmosDBMongoVCoreConnectionString", 
+    storeConnectionName: "CosmosDBMongoVCoreConnectionString", 
     collection: "openai-index", 
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
@@ -38,7 +38,7 @@ app.http('IngestFile', {
 
 const semanticSearchInput = input.generic({
     type: "semanticSearch",
-    connectionName: "CosmosDBMongoVCoreConnectionString",
+    searchConnectionName: "CosmosDBMongoVCoreConnectionString",
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/samples/rag-cosmosdb/typescript/package-lock.json
+++ b/samples/rag-cosmosdb/typescript/package-lock.json
@@ -11,7 +11,7 @@
         "@azure/functions": "^4.11.0"
       },
       "devDependencies": {
-        "@types/node": "^18.x",
+        "@types/node": "^22.x",
         "rimraf": "^5.0.0",
         "typescript": "^4.0.0"
       }
@@ -66,10 +66,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz",
-      "integrity": "sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ==",
-      "dev": true
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -450,6 +454,13 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -594,10 +605,13 @@
       "optional": true
     },
     "@types/node": {
-      "version": "18.15.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz",
-      "integrity": "sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ==",
-      "dev": true
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "ansi-regex": {
       "version": "6.2.2",
@@ -727,7 +741,7 @@
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       }
     },
     "minipass": {
@@ -863,6 +877,12 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "which": {

--- a/samples/rag-cosmosdb/typescript/package.json
+++ b/samples/rag-cosmosdb/typescript/package.json
@@ -13,7 +13,7 @@
     "@azure/functions": "^4.11.0"
   },
   "devDependencies": {
-    "@types/node": "^18.x",
+    "@types/node": "^22.x",
     "typescript": "^4.0.0",
     "rimraf": "^5.0.0"
   },

--- a/samples/rag-cosmosdb/typescript/src/app.ts
+++ b/samples/rag-cosmosdb/typescript/src/app.ts
@@ -9,7 +9,7 @@ const embeddingsStoreOutput = output.generic({
     type: "embeddingsStore",
     input: "{url}", 
     inputType: "url", 
-    connectionName: "CosmosDBMongoVCoreConnectionString", 
+    storeConnectionName: "CosmosDBMongoVCoreConnectionString", 
     collection: "openai-index", 
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
@@ -41,7 +41,7 @@ app.http('IngestFile', {
 
 const semanticSearchInput = input.generic({
     type: "semanticSearch",
-    connectionName: "CosmosDBMongoVCoreConnectionString",
+    searchConnectionName: "CosmosDBMongoVCoreConnectionString",
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -37,9 +37,9 @@
     <!-- Version for azure AI search webjobs and worker project -->
     <AzureAISearchVersion>0.5.0-alpha</AzureAISearchVersion>
     <!-- Version for CosmosDB search webjobs and worker project -->
-    <CosmosDBSearchVersion>0.4.0-alpha</CosmosDBSearchVersion>
+    <CosmosDBSearchVersion>0.5.0-alpha</CosmosDBSearchVersion>
     <!-- Version for CosmosDB NoSql vector search webjobs and worker project -->
-    <CosmosDBNoSqlSearchVersion>0.1.0-alpha</CosmosDBNoSqlSearchVersion>
+    <CosmosDBNoSqlSearchVersion>0.2.0-alpha</CosmosDBNoSqlSearchVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch/CHANGELOG.md
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.0 - TBD
+
+### Changed
+
+- Updated Microsoft.Azure.Cosmos from 3.49.0 to 3.58.0
+  - Minor version upgrade with no code changes required
+
 ## v0.1.0 - 2025/05/08
 
 ### Added

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch.csproj
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch/WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.49.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CHANGELOG.md
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0 - TBD
+
+### Changed
+
+- Updated MongoDB.Driver from 2.30.0 to 3.7.1
+- Fixed `CosmosDBSearchProvider` to properly initialize `databaseName` and `indexName` in constructor
+  - Previously, `SearchAsync` could fail if called before `AddDocumentAsync` due to uninitialized database name
+
 ## v0.4.0 - 2025/05/05
 
 ### Added

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchProvider.cs
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/CosmosDBSearchProvider.cs
@@ -68,6 +68,9 @@ sealed class CosmosDBSearchProvider : ISearchProvider
         this.cosmosDBSearchConfigOptions = cosmosDBSearchConfigOptions;
         this.logger = loggerFactory.CreateLogger<CosmosDBSearchProvider>();
         this.configuration = configuration;
+
+        this.databaseName = cosmosDBSearchConfigOptions.Value.DatabaseName;
+        this.indexName = cosmosDBSearchConfigOptions.Value.IndexName;
     }
 
     /// <summary>
@@ -83,9 +86,7 @@ sealed class CosmosDBSearchProvider : ISearchProvider
             _ => this.CreateMongoClient(document.ConnectionInfo.ConnectionName)
         );
 
-        this.databaseName = this.cosmosDBSearchConfigOptions.Value.DatabaseName;
         this.collectionName = document.ConnectionInfo.CollectionName;
-        this.indexName = this.cosmosDBSearchConfigOptions.Value.IndexName;
         this.CreateVectorIndexIfNotExists(cosmosClient);
 
         await this.UpsertVectorAsync(cosmosClient, document);
@@ -121,7 +122,7 @@ sealed class CosmosDBSearchProvider : ISearchProvider
 
             IMongoCollection<BsonDocument> collection = cosmosClient
                 .GetDatabase(this.databaseName)
-                .GetCollection<BsonDocument>(this.collectionName);
+                .GetCollection<BsonDocument>(request.ConnectionInfo.CollectionName);
 
             // Search Azure Cosmos DB for MongoDB vCore collection for similar embeddings and project fields.
             BsonDocument[]? pipeline = null;

--- a/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/WebJobs.Extensions.OpenAI.CosmosDBSearch.csproj
+++ b/src/WebJobs.Extensions.OpenAI.CosmosDBSearch/WebJobs.Extensions.OpenAI.CosmosDBSearch.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.*" />
+    <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Upgrade CosmosDB SDK packages to latest versions:
- **MongoDB.Driver**: 2.30.0 → 3.7.1 (major version upgrade - needed to do this as CosmosDB Mongo extension has already updated to this version in preview bundle and both extensions shared this package)
- **Microsoft.Azure.Cosmos**: 3.49.0 → 3.58.0 (minor version upgrade)

## API Compatibility Analysis

### MongoDB.Driver 2.30.0 → 3.7.1
Major version upgrade. Ran apicompat tool - 327 breaking changes in the SDK, but **none affect our code**. All APIs we use continue to work:
- `MongoClientSettings.FromConnectionString` ✓
- `MongoClient.GetDatabase` ✓
- `IMongoCollection.AggregateAsync` ✓
- `IMongoCollection.InsertManyAsync` ✓
- `BsonDocument`, `BsonArray`, `BsonDouble` ✓

**Bug fix:** Fixed a latent bug in `CosmosDBSearchProvider.cs` where `databaseName`/`indexName` weren't initialized in the constructor. This caused `SearchAsync` to fail if called before `AddDocumentAsync`.

### Microsoft.Azure.Cosmos 3.49.0 → 3.58.0
Minor version upgrade. Ran apicompat tool - 1 breaking change (`CrossRegionHedgingStrategy` method signature changed), but **we don't use this API**. All APIs we use continue to work:
- `CosmosClient`, `CosmosClientOptions` ✓
- `Database.CreateContainerIfNotExistsAsync` ✓
- `Container.UpsertItemAsync` ✓
- `Container.GetItemQueryIterator` ✓
- `VectorEmbeddingPolicy`, `IndexingPolicy` ✓

## Test Results

All samples tested against Azure resources with existing data (query + ingest verified).

| Sample | MongoDB 3.7.1 | NoSQL 3.58.0 |
|--------|---------------|--------------|
| Python | ✅ PASS | ✅ PASS |
| TypeScript | ✅ PASS | ✅ PASS |
| JavaScript | ✅ PASS | ✅ PASS |
| C# Legacy | ✅ PASS | ✅ PASS |
| C# ooproc | ✅ PASS | ✅ PASS |
| Java | ✅ PASS | ✅ PASS |

## Changes

### Bug Fixes
- `CosmosDBSearchProvider.cs`: Initialize `databaseName`/`indexName` in constructor to fix search-before-ingest scenario

### Package Updates
- `WebJobs.Extensions.OpenAI.CosmosDBSearch`: MongoDB.Driver 2.30.0 → 3.7.1
- `WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch`: Microsoft.Azure.Cosmos 3.49.0 → 3.58.0

### Sample Updates
- Updated csharp-ooproc sample csprojs with latest NuGet package versions
- Added `[HttpResult]` attribute required by Worker.Sdk 2.0.7 analyzer
- Updated TypeScript/JavaScript samples for binding property name changes
- Updated `@types/node` from ^18.x to ^22.x in TypeScript samples
- Updated Java samples: azure-functions-maven-plugin 1.29.0 → 1.41.0, azure-functions-java-library 3.1.0 → 3.2.4

### CHANGELOGs
- Added v0.5.0 entry for CosmosDBSearch (MongoDB.Driver upgrade + bug fix)
- Added v0.2.0 entry for CosmosDBNoSqlSearch (Microsoft.Azure.Cosmos upgrade)

## Verified DLL Versions
- `MongoDB.Driver.dll`: 3.7.1 ✓
- `Microsoft.Azure.Cosmos.Client.dll`: 3.58.0 ✓