### PR TITLE
Update sample HTTP triggers from anonymous to function auth level

### DIFF
--- a/samples/assistant/csharp-legacy/AssistantApis.cs
+++ b/samples/assistant/csharp-legacy/AssistantApis.cs
@@ -25,7 +25,7 @@ static class AssistantApis
     /// </summary>
     [FunctionName(nameof(CreateAssistant))]
     public static async Task<IActionResult> CreateAssistant(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "assistants/{assistantId}")] HttpRequest req,
+        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "assistants/{assistantId}")] HttpRequest req,
         string assistantId,
         [AssistantCreate] IAsyncCollector<AssistantCreateRequest> createRequests)
     {
@@ -49,7 +49,7 @@ static class AssistantApis
     /// </summary>
     [FunctionName(nameof(PostUserQuery))]
     public static IActionResult PostUserQuery(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "assistants/{assistantId}")] HttpRequest req,
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "assistants/{assistantId}")] HttpRequest req,
         string assistantId,
         [AssistantPost("{assistantId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState updatedState)
     {
@@ -61,7 +61,7 @@ static class AssistantApis
     /// </summary>
     [FunctionName(nameof(GetChatState))]
     public static AssistantState GetChatState(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "assistants/{assistantId}")] HttpRequest req,
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "assistants/{assistantId}")] HttpRequest req,
         string assistantId,
         [AssistantQuery("{assistantId}", TimestampUtc = "{Query.timestampUTC}", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
     {

--- a/samples/assistant/csharp-ooproc/AssistantApis.cs
+++ b/samples/assistant/csharp-ooproc/AssistantApis.cs
@@ -21,7 +21,7 @@ static class AssistantApis
     /// </summary>
     [Function(nameof(CreateAssistant))]
     public static async Task<CreateChatBotOutput> CreateAssistant(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "assistants/{assistantId}")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "assistants/{assistantId}")] HttpRequestData req,
         string assistantId)
     {
         string instructions =
@@ -60,7 +60,7 @@ static class AssistantApis
     /// </summary>
     [Function(nameof(PostUserQuery))]
     public static IActionResult PostUserQuery(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "assistants/{assistantId}")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "assistants/{assistantId}")] HttpRequestData req,
         string assistantId,
         [AssistantPostInput("{assistantId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
     {
@@ -72,7 +72,7 @@ static class AssistantApis
     /// </summary>
     [Function(nameof(GetChatState))]
     public static IActionResult GetChatState(
-       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "assistants/{assistantId}")] HttpRequestData req,
+       [HttpTrigger(AuthorizationLevel.Function, "get", Route = "assistants/{assistantId}")] HttpRequestData req,
        string assistantId,
        [AssistantQueryInput("{assistantId}", TimestampUtc = "{Query.timestampUTC}", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
     {

--- a/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
+++ b/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
@@ -51,7 +51,7 @@ public class AssistantApis {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.PUT}, 
-            authLevel = AuthorizationLevel.ANONYMOUS, 
+            authLevel = AuthorizationLevel.FUNCTION, 
             route = "assistants/{assistantId}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("assistantId") String assistantId,
@@ -84,7 +84,7 @@ public class AssistantApis {
         @HttpTrigger(
             name = "req",
             methods = {HttpMethod.GET}, 
-            authLevel = AuthorizationLevel.ANONYMOUS,
+            authLevel = AuthorizationLevel.FUNCTION,
             route = "assistants/{assistantId}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("assistantId") String assistantId,        
@@ -104,7 +104,7 @@ public class AssistantApis {
         @HttpTrigger(
             name = "req",
             methods = {HttpMethod.POST}, 
-            authLevel = AuthorizationLevel.ANONYMOUS,
+            authLevel = AuthorizationLevel.FUNCTION,
             route = "assistants/{assistantId}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("assistantId") String assistantId,        

--- a/samples/assistant/javascript/src/functions/assistantApis.js
+++ b/samples/assistant/javascript/src/functions/assistantApis.js
@@ -12,7 +12,7 @@ const chatBotCreateOutput = output.generic({
 app.http('CreateAssistant', {
     methods: ['PUT'],
     route: 'assistants/{assistantId}',
-    authLevel: 'anonymous',
+    authLevel: 'function',
     extraOutputs: [chatBotCreateOutput],
     handler: async (request, context) => {
         const assistantId = request.params.assistantId
@@ -44,7 +44,7 @@ const assistantPostInput = input.generic({
 app.http('PostUserResponse', {
     methods: ['POST'],
     route: 'assistants/{assistantId}',
-    authLevel: 'anonymous',
+    authLevel: 'function',
     extraInputs: [assistantPostInput],
     handler: async (_, context) => {
         const chatState = context.extraInputs.get(assistantPostInput)
@@ -70,7 +70,7 @@ const chatBotQueryInput = input.generic({
 app.http('GetChatState', {
     methods: ['GET'],
     route: 'assistants/{assistantId}',
-    authLevel: 'anonymous',
+    authLevel: 'function',
     extraInputs: [chatBotQueryInput],
     handler: async (_, context) => {
         const state = context.extraInputs.get(chatBotQueryInput)

--- a/samples/assistant/python/function_app.py
+++ b/samples/assistant/python/function_app.py
@@ -3,7 +3,7 @@ import azure.functions as func
 from assistant_apis import apis
 from assistant_skills import skills
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 
 app.register_functions(apis)
 app.register_functions(skills)

--- a/samples/assistant/typescript/src/functions/assistantApis.ts
+++ b/samples/assistant/typescript/src/functions/assistantApis.ts
@@ -12,7 +12,7 @@ const chatBotCreateOutput = output.generic({
 app.http('CreateAssistant', {
     methods: ['PUT'],
     route: 'assistants/{assistantId}',
-    authLevel: 'anonymous',
+    authLevel: 'function',
     extraOutputs: [chatBotCreateOutput],
     handler: async (request: HttpRequest, context: InvocationContext) => {
         const assistantId = request.params.assistantId
@@ -44,7 +44,7 @@ const assistantPostInput = input.generic({
 app.http('PostUserResponse', {
     methods: ['POST'],
     route: 'assistants/{assistantId}',
-    authLevel: 'anonymous',
+    authLevel: 'function',
     extraInputs: [assistantPostInput],
     handler: async (_, context) => {
         const chatState: any = context.extraInputs.get(assistantPostInput)
@@ -70,7 +70,7 @@ const chatBotQueryInput = input.generic({
 app.http('GetChatState', {
     methods: ['GET'],
     route: 'assistants/{assistantId}',
-    authLevel: 'anonymous',
+    authLevel: 'function',
     extraInputs: [chatBotQueryInput],
     handler: async (_, context) => {
         const state: any = context.extraInputs.get(chatBotQueryInput)

--- a/samples/chat/csharp-legacy/ChatBot.cs
+++ b/samples/chat/csharp-legacy/ChatBot.cs
@@ -24,7 +24,7 @@ public static class ChatBot
 
     [FunctionName(nameof(CreateChatBot))]
     public static async Task<IActionResult> CreateChatBot(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "chats/{chatId}")] CreateRequest req,
+        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "chats/{chatId}")] CreateRequest req,
         string chatId,
         [AssistantCreate] IAsyncCollector<AssistantCreateRequest> createRequests)
     {
@@ -40,7 +40,7 @@ public static class ChatBot
 
     [FunctionName(nameof(GetChatState))]
     public static AssistantState GetChatState(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "chats/{chatId}")] HttpRequest req,
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "chats/{chatId}")] HttpRequest req,
         string chatId,
         [AssistantQuery("{chatId}", TimestampUtc = "{Query.timestampUTC}", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
     {
@@ -49,7 +49,7 @@ public static class ChatBot
 
     [FunctionName(nameof(PostUserResponse))]
     public static IActionResult PostUserResponse(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "chats/{chatId}")] HttpRequest req,
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "chats/{chatId}")] HttpRequest req,
         string chatId,
         [AssistantPost("{chatId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState updatedState)
     {

--- a/samples/chat/java/src/main/java/com/azfs/ChatBot.java
+++ b/samples/chat/java/src/main/java/com/azfs/ChatBot.java
@@ -38,7 +38,7 @@ public class ChatBot {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.PUT},
-            authLevel = AuthorizationLevel.ANONYMOUS, 
+            authLevel = AuthorizationLevel.FUNCTION, 
             route = "chats/{chatId}") 
             HttpRequestMessage<Optional<CreateRequest>> request,
         @BindingName("chatId") String chatId,
@@ -79,7 +79,7 @@ public class ChatBot {
         @HttpTrigger(
             name = "req",
             methods = {HttpMethod.GET}, 
-            authLevel = AuthorizationLevel.ANONYMOUS,
+            authLevel = AuthorizationLevel.FUNCTION,
             route = "chats/{chatId}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("chatId") String chatId,        
@@ -96,7 +96,7 @@ public class ChatBot {
         @HttpTrigger(
             name = "req",
             methods = {HttpMethod.POST}, 
-            authLevel = AuthorizationLevel.ANONYMOUS,
+            authLevel = AuthorizationLevel.FUNCTION,
             route = "chats/{chatId}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("chatId") String chatId,        

--- a/samples/embeddings/java/src/main/java/com/azfs/EmbeddingsGenerator.java
+++ b/samples/embeddings/java/src/main/java/com/azfs/EmbeddingsGenerator.java
@@ -28,7 +28,7 @@ public class EmbeddingsGenerator {
             @HttpTrigger(
                 name = "req", 
                 methods = {HttpMethod.POST},
-                authLevel = AuthorizationLevel.ANONYMOUS,
+                authLevel = AuthorizationLevel.FUNCTION,
                 route = "embeddings")
             HttpRequestMessage<EmbeddingsRequest> request,
             @EmbeddingsInput(name = "Embeddings", input = "{RawText}", inputType = InputType.RawText, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") String embeddingsContext,
@@ -61,7 +61,7 @@ public class EmbeddingsGenerator {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS,
+            authLevel = AuthorizationLevel.FUNCTION,
             route = "embeddings-from-file")
         HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsInput(name = "Embeddings", input = "{FilePath}", inputType = InputType.FilePath, maxChunkLength = 512, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") String embeddingsContext,
@@ -94,7 +94,7 @@ public class EmbeddingsGenerator {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS,
+            authLevel = AuthorizationLevel.FUNCTION,
             route = "embeddings-from-url")
         HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsInput(name = "Embeddings", input = "{Url}", inputType = InputType.Url, maxChunkLength = 512, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") String embeddingsContext,

--- a/samples/rag-aisearch/java/src/main/java/com/azfs/FilePrompt.java
+++ b/samples/rag-aisearch/java/src/main/java/com/azfs/FilePrompt.java
@@ -31,7 +31,7 @@ public class FilePrompt {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "AISearchEndpoint", collection = "openai-index",
@@ -77,7 +77,7 @@ public class FilePrompt {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
         @SemanticSearch(name = "search", searchConnectionName = "AISearchEndpoint", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
         final ExecutionContext context) {

--- a/samples/rag-cosmosdb-nosql/java/src/main/java/com/azfs/FilePrompt.java
+++ b/samples/rag-cosmosdb-nosql/java/src/main/java/com/azfs/FilePrompt.java
@@ -31,7 +31,7 @@ public class FilePrompt {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "CosmosDBNoSqlEndpoint", collection = "openai-index",
@@ -77,7 +77,7 @@ public class FilePrompt {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
         @SemanticSearch(name = "search", searchConnectionName = "CosmosDBNoSqlEndpoint", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
         final ExecutionContext context) {

--- a/samples/rag-cosmosdb/java/src/main/java/com/azfs/FilePrompt.java
+++ b/samples/rag-cosmosdb/java/src/main/java/com/azfs/FilePrompt.java
@@ -26,7 +26,7 @@ public class FilePrompt {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "CosmosDBMongoVCoreConnectionString", collection = "openai-index",
@@ -72,7 +72,7 @@ public class FilePrompt {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
         @SemanticSearch(name = "search", searchConnectionName = "CosmosDBMongoVCoreConnectionString", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
         final ExecutionContext context) {

--- a/samples/rag-kusto/java/src/main/java/com/azfs/EmailPromptDemo.java
+++ b/samples/rag-kusto/java/src/main/java/com/azfs/EmailPromptDemo.java
@@ -32,7 +32,7 @@ public class EmailPromptDemo {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "KustoConnectionString", collection = "Documents",
@@ -78,7 +78,7 @@ public class EmailPromptDemo {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS)
+            authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
         @SemanticSearch(name = "search", searchConnectionName = "KustoConnectionString", collection = "Documents", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
         final ExecutionContext context) {

--- a/samples/textcompletion/java/src/main/java/com/azfs/TextCompletions.java
+++ b/samples/textcompletion/java/src/main/java/com/azfs/TextCompletions.java
@@ -33,7 +33,7 @@ public class TextCompletions {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.GET},
-            authLevel = AuthorizationLevel.ANONYMOUS, 
+            authLevel = AuthorizationLevel.FUNCTION, 
             route = "whois/{name}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("name") String name,
@@ -54,7 +54,7 @@ public class TextCompletions {
         @HttpTrigger(
             name = "req", 
             methods = {HttpMethod.POST},
-            authLevel = AuthorizationLevel.ANONYMOUS) 
+            authLevel = AuthorizationLevel.FUNCTION) 
             HttpRequestMessage<Optional<String>> request,
         @TextCompletion(prompt = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", name = "response", isReasoningModel = false) TextCompletionResponse response,
         final ExecutionContext context) {


### PR DESCRIPTION
Updates all language samples to use function level authorization for HTTP triggers instead of anonymous.

Changes:
- C#: assistant (legacy and out-of-proc) and chat (legacy) samples changed from AuthorizationLevel.Anonymous to AuthorizationLevel.Function
- Java: assistant, chat, embeddings, textcompletion, rag-kusto, rag-cosmosdb, rag-cosmosdb-nosql, and rag-aisearch samples changed from AuthorizationLevel.ANONYMOUS to AuthorizationLevel.FUNCTION
- TypeScript and JavaScript: assistant sample authLevel changed from anonymous to function
- Python: assistant function app http_auth_level changed from AuthLevel.ANONYMOUS to AuthLevel.FUNCTION

This aligns the remaining samples with the rest of the samples, which already use function level authorization.

Addresses 16 - https://github.com/Azure/azure-functions-bucees-planning/issues/1098