### PR TITLE
Update samples to demonstrate Entra + UAMI with new `AIConnectionName` API

### DIFF
--- a/samples/assistant/csharp-legacy/AssistantApis.cs
+++ b/samples/assistant/csharp-legacy/AssistantApis.cs
@@ -51,7 +51,7 @@ static class AssistantApis
     public static IActionResult PostUserQuery(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "assistants/{assistantId}")] HttpRequest req,
         string assistantId,
-        [AssistantPost("{assistantId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState updatedState)
+        [AssistantPost("{assistantId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState updatedState)
     {
         return new OkObjectResult(updatedState.RecentMessages.Any() ? updatedState.RecentMessages[updatedState.RecentMessages.Count - 1].Content : "No response returned.");
     }

--- a/samples/assistant/csharp-legacy/local.settings.json
+++ b/samples/assistant/csharp-legacy/local.settings.json
@@ -7,7 +7,9 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "todoDB",
     "CosmosContainerName": "myTasks",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/assistant/csharp-legacy/local.settings.json
+++ b/samples/assistant/csharp-legacy/local.settings.json
@@ -7,7 +7,7 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "todoDB",
     "CosmosContainerName": "myTasks",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/assistant/csharp-ooproc/AssistantApis.cs
+++ b/samples/assistant/csharp-ooproc/AssistantApis.cs
@@ -62,7 +62,7 @@ static class AssistantApis
     public static IActionResult PostUserQuery(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "assistants/{assistantId}")] HttpRequestData req,
         string assistantId,
-        [AssistantPostInput("{assistantId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
+        [AssistantPostInput("{assistantId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
     {
         return new OkObjectResult(state.RecentMessages.Any() ? state.RecentMessages[state.RecentMessages.Count - 1].Content : "No response returned.");
     }

--- a/samples/assistant/csharp-ooproc/local.settings.json
+++ b/samples/assistant/csharp-ooproc/local.settings.json
@@ -6,7 +6,7 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "todoDB",
     "CosmosContainerName": "myTasks",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/assistant/csharp-ooproc/local.settings.json
+++ b/samples/assistant/csharp-ooproc/local.settings.json
@@ -6,7 +6,9 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "todoDB",
     "CosmosContainerName": "myTasks",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/assistant/java/local.settings.json
+++ b/samples/assistant/java/local.settings.json
@@ -6,7 +6,9 @@
     "CosmosDbConnectionEndpoint": "Local Cosmos DB emulator or Cosmos DB in Azure Cosmos end point",
     "CosmosDatabaseName": "todoDB",
     "CosmosContainerName": "myTasks",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/assistant/java/local.settings.json
+++ b/samples/assistant/java/local.settings.json
@@ -6,7 +6,7 @@
     "CosmosDbConnectionEndpoint": "Local Cosmos DB emulator or Cosmos DB in Azure Cosmos end point",
     "CosmosDatabaseName": "todoDB",
     "CosmosContainerName": "myTasks",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
+++ b/samples/assistant/java/src/main/java/com/azfs/AssistantApis.java
@@ -108,7 +108,7 @@ public class AssistantApis {
             route = "assistants/{assistantId}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("assistantId") String assistantId,        
-        @AssistantPost(name="newMessages", id = "{assistantId}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", userMessage = "{Query.message}", chatStorageConnectionSetting = DEFAULT_CHATSTORAGE, collectionName = DEFAULT_COLLECTION) AssistantState state,
+        @AssistantPost(name="newMessages", id = "{assistantId}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI", userMessage = "{Query.message}", chatStorageConnectionSetting = DEFAULT_CHATSTORAGE, collectionName = DEFAULT_COLLECTION) AssistantState state,
         final ExecutionContext context) {
             
             List<AssistantMessage> recentMessages = state.getRecentMessages();

--- a/samples/assistant/javascript/local.settings.json
+++ b/samples/assistant/javascript/local.settings.json
@@ -7,7 +7,9 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "",
     "CosmosContainerName": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/assistant/javascript/local.settings.json
+++ b/samples/assistant/javascript/local.settings.json
@@ -7,7 +7,7 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "",
     "CosmosContainerName": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/assistant/javascript/src/functions/assistantApis.js
+++ b/samples/assistant/javascript/src/functions/assistantApis.js
@@ -37,6 +37,7 @@ const assistantPostInput = input.generic({
     type: 'assistantPost',
     id: '{assistantId}',
     chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI',
     userMessage: '{Query.message}',
     chatStorageConnectionSetting: CHAT_STORAGE_CONNECTION_SETTING,
     collectionName: COLLECTION_NAME

--- a/samples/assistant/powershell/PostUserQuery/function.json
+++ b/samples/assistant/powershell/PostUserQuery/function.json
@@ -24,7 +24,8 @@
       "userMessage": "{Query.message}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",
       "chatStorageConnectionSetting": "AzureWebJobsStorage",
-      "collectionName": "ChatState"
+      "collectionName": "ChatState",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/assistant/powershell/local.settings.json
+++ b/samples/assistant/powershell/local.settings.json
@@ -7,7 +7,9 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "testdb",
     "CosmosContainerName": "my-todos",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/assistant/powershell/local.settings.json
+++ b/samples/assistant/powershell/local.settings.json
@@ -7,7 +7,7 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "testdb",
     "CosmosContainerName": "my-todos",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/assistant/python/assistant_apis.py
+++ b/samples/assistant/python/assistant_apis.py
@@ -38,6 +38,7 @@ def create_assistant(
     id="{assistantId}",
     user_message="{Query.message}",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
     chat_storage_connection_setting=DEFAULT_CHAT_STORAGE_SETTING,
     collection_name=DEFAULT_CHAT_COLLECTION_NAME,
 )

--- a/samples/assistant/python/local.settings.json
+++ b/samples/assistant/python/local.settings.json
@@ -7,7 +7,7 @@
     "CosmosDbConnectionEndpoint": "Placeholder for Azure Cosmos DB for NoSQL Endpoint",
     "CosmosDatabaseName": "testdb",
     "CosmosContainerName": "my-todos",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/assistant/python/local.settings.json
+++ b/samples/assistant/python/local.settings.json
@@ -7,7 +7,9 @@
     "CosmosDbConnectionEndpoint": "Placeholder for Azure Cosmos DB for NoSQL Endpoint",
     "CosmosDatabaseName": "testdb",
     "CosmosContainerName": "my-todos",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }

--- a/samples/assistant/typescript/local.settings.json
+++ b/samples/assistant/typescript/local.settings.json
@@ -7,7 +7,9 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "",
     "CosmosContainerName": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/assistant/typescript/local.settings.json
+++ b/samples/assistant/typescript/local.settings.json
@@ -7,7 +7,7 @@
     "CosmosDbConnectionString": "Local Cosmos DB emulator or Cosmos DB in Azure connection string",
     "CosmosDatabaseName": "",
     "CosmosContainerName": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/assistant/typescript/src/functions/assistantApis.ts
+++ b/samples/assistant/typescript/src/functions/assistantApis.ts
@@ -37,6 +37,7 @@ const assistantPostInput = input.generic({
     type: 'assistantPost',
     id: '{assistantId}',
     chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI',
     userMessage: '{Query.message}',
     chatStorageConnectionSetting: CHAT_STORAGE_CONNECTION_SETTING,
     collectionName: COLLECTION_NAME

--- a/samples/chat/csharp-legacy/ChatBot.cs
+++ b/samples/chat/csharp-legacy/ChatBot.cs
@@ -51,7 +51,7 @@ public static class ChatBot
     public static IActionResult PostUserResponse(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "chats/{chatId}")] HttpRequest req,
         string chatId,
-        [AssistantPost("{chatId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState updatedState)
+        [AssistantPost("{chatId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState updatedState)
     {
         return new OkObjectResult(updatedState.RecentMessages.Any() ? updatedState.RecentMessages[updatedState.RecentMessages.Count - 1].Content : "No response returned.");
     }

--- a/samples/chat/csharp-legacy/local.settings.json
+++ b/samples/chat/csharp-legacy/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/chat/csharp-legacy/local.settings.json
+++ b/samples/chat/csharp-legacy/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/chat/csharp-ooproc/ChatBot.cs
+++ b/samples/chat/csharp-ooproc/ChatBot.cs
@@ -66,7 +66,7 @@ public static class ChatBot
     public static IActionResult PostUserResponse(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "chats/{chatId}")] HttpRequestData req,
         string chatId,
-        [AssistantPostInput("{chatId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
+        [AssistantPostInput("{chatId}", "{Query.message}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI", ChatStorageConnectionSetting = DefaultChatStorageConnectionSetting, CollectionName = DefaultCollectionName)] AssistantState state)
     {
         return new OkObjectResult(state.RecentMessages.LastOrDefault()?.Content ?? "No response returned.");
     }

--- a/samples/chat/csharp-ooproc/local.settings.json
+++ b/samples/chat/csharp-ooproc/local.settings.json
@@ -3,7 +3,9 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/chat/csharp-ooproc/local.settings.json
+++ b/samples/chat/csharp-ooproc/local.settings.json
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/chat/java/local.settings.json
+++ b/samples/chat/java/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "java",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/chat/java/local.settings.json
+++ b/samples/chat/java/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "java",
-    "AZURE_OPENAI_ENDPOINT": "https://<resource-name>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/chat/java/src/main/java/com/azfs/ChatBot.java
+++ b/samples/chat/java/src/main/java/com/azfs/ChatBot.java
@@ -100,7 +100,7 @@ public class ChatBot {
             route = "chats/{chatId}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("chatId") String chatId,        
-        @AssistantPost(name="newMessages", id = "{chatId}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", userMessage = "{Query.message}") AssistantState state,
+        @AssistantPost(name="newMessages", id = "{chatId}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI", userMessage = "{Query.message}") AssistantState state,
         final ExecutionContext context) {
 
             List<AssistantMessage> recentMessages = state.getRecentMessages();

--- a/samples/chat/javascript/local.settings.json
+++ b/samples/chat/javascript/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/chat/javascript/local.settings.json
+++ b/samples/chat/javascript/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/chat/javascript/src/app.js
+++ b/samples/chat/javascript/src/app.js
@@ -53,6 +53,7 @@ const assistantPostInput = input.generic({
     type: 'assistantPost',
     id: '{chatID}',
     chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI',
     userMessage: '{Query.message}',
     chatStorageConnectionSetting: CHAT_STORAGE_CONNECTION_SETTING,
     collectionName: COLLECTION_NAME

--- a/samples/chat/powershell/PostUserResponse/function.json
+++ b/samples/chat/powershell/PostUserResponse/function.json
@@ -23,7 +23,8 @@
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",
       "userMessage": "{Query.message}",
       "chatStorageConnectionSetting": "AzureWebJobsStorage",
-      "collectionName": "ChatState"
+      "collectionName": "ChatState",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/chat/powershell/local.settings.json
+++ b/samples/chat/powershell/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/chat/powershell/local.settings.json
+++ b/samples/chat/powershell/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/chat/python/function_app.py
+++ b/samples/chat/python/function_app.py
@@ -55,6 +55,7 @@ def get_chat_state(req: func.HttpRequest, state: str) -> func.HttpResponse:
     id="{chatId}",
     user_message="{Query.message}",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
     chat_storage_connection_setting=DEFAULT_CHAT_STORAGE_SETTING,
     collection_name=DEFAULT_CHAT_COLLECTION_NAME,
 )

--- a/samples/chat/python/local.settings.json
+++ b/samples/chat/python/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/chat/python/local.settings.json
+++ b/samples/chat/python/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }

--- a/samples/chat/typescript/local.settings.json
+++ b/samples/chat/typescript/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/chat/typescript/local.settings.json
+++ b/samples/chat/typescript/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/chat/typescript/src/functions/app.ts
+++ b/samples/chat/typescript/src/functions/app.ts
@@ -53,6 +53,7 @@ const assistantPostInput = input.generic({
     type: 'assistantPost',
     id: '{chatID}',
     chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI',
     userMessage: '{Query.message}',
     chatStorageConnectionSetting: CHAT_STORAGE_CONNECTION_SETTING,
     collectionName: COLLECTION_NAME

--- a/samples/embeddings/csharp-legacy/EmbeddingsLegacy.cs
+++ b/samples/embeddings/csharp-legacy/EmbeddingsLegacy.cs
@@ -22,7 +22,7 @@ public static class EmbeddingsLegacy
     [FunctionName(nameof(GenerateEmbeddings_Http_Request))]
     public static void GenerateEmbeddings_Http_Request(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "embeddings")] EmbeddingsRequest req,
-        [Embeddings("{RawText}", InputType.RawText, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] EmbeddingsContext embeddings,
+        [Embeddings("{RawText}", InputType.RawText, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] EmbeddingsContext embeddings,
         ILogger logger)
     {
         logger.LogInformation(
@@ -40,7 +40,7 @@ public static class EmbeddingsLegacy
     [FunctionName(nameof(GetEmbeddings_Http_FilePath))]
     public static void GetEmbeddings_Http_FilePath(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "embeddings-from-file")] EmbeddingsRequest req,
-        [Embeddings("{FilePath}", InputType.FilePath, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", MaxChunkLength = 512)] EmbeddingsContext embeddings,
+        [Embeddings("{FilePath}", InputType.FilePath, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI", MaxChunkLength = 512)] EmbeddingsContext embeddings,
         ILogger logger)
     {
         logger.LogInformation(
@@ -58,7 +58,7 @@ public static class EmbeddingsLegacy
     [FunctionName(nameof(GetEmbeddings_Http_Url))]
     public static void GetEmbeddings_Http_Url(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "embeddings-from-url")] EmbeddingsRequest req,
-        [Embeddings("{Url}", InputType.Url, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", MaxChunkLength = 512)] EmbeddingsContext embeddings,
+        [Embeddings("{Url}", InputType.Url, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI", MaxChunkLength = 512)] EmbeddingsContext embeddings,
         ILogger logger)
     {
         logger.LogInformation(

--- a/samples/embeddings/csharp-legacy/local.settings.json
+++ b/samples/embeddings/csharp-legacy/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/embeddings/csharp-legacy/local.settings.json
+++ b/samples/embeddings/csharp-legacy/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/embeddings/csharp-ooproc/Embeddings/EmbeddingsGenerator.cs
+++ b/samples/embeddings/csharp-ooproc/Embeddings/EmbeddingsGenerator.cs
@@ -41,7 +41,7 @@ public class EmbeddingsGenerator
     [Function(nameof(GenerateEmbeddings_Http_RequestAsync))]
     public async Task GenerateEmbeddings_Http_RequestAsync(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "embeddings")] HttpRequestData req,
-        [EmbeddingsInput("{rawText}", InputType.RawText, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] EmbeddingsContext embeddings)
+        [EmbeddingsInput("{rawText}", InputType.RawText, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] EmbeddingsContext embeddings)
     {
         using StreamReader reader = new(req.Body);
         string request = await reader.ReadToEndAsync();
@@ -63,7 +63,7 @@ public class EmbeddingsGenerator
     [Function(nameof(GetEmbeddings_Http_FilePath))]
     public async Task GetEmbeddings_Http_FilePath(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "embeddings-from-file")] HttpRequestData req,
-        [EmbeddingsInput("{filePath}", InputType.FilePath, MaxChunkLength = 512, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] EmbeddingsContext embeddings)
+        [EmbeddingsInput("{filePath}", InputType.FilePath, MaxChunkLength = 512, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] EmbeddingsContext embeddings)
     {
         using StreamReader reader = new(req.Body);
         string request = await reader.ReadToEndAsync();
@@ -84,7 +84,7 @@ public class EmbeddingsGenerator
     [Function(nameof(GetEmbeddings_Http_URL))]
     public async Task GetEmbeddings_Http_URL(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "embeddings-from-url")] HttpRequestData req,
-        [EmbeddingsInput("{url}", InputType.Url, MaxChunkLength = 512, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] EmbeddingsContext embeddings)
+        [EmbeddingsInput("{url}", InputType.Url, MaxChunkLength = 512, EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] EmbeddingsContext embeddings)
     {
         using StreamReader reader = new(req.Body);
         string request = await reader.ReadToEndAsync();

--- a/samples/embeddings/csharp-ooproc/Embeddings/local.settings.json
+++ b/samples/embeddings/csharp-ooproc/Embeddings/local.settings.json
@@ -3,7 +3,7 @@
     "Values": {
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-        "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+        "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
         "AzureOpenAI__credential": "managedidentity",
         "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
         "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"

--- a/samples/embeddings/csharp-ooproc/Embeddings/local.settings.json
+++ b/samples/embeddings/csharp-ooproc/Embeddings/local.settings.json
@@ -1,9 +1,11 @@
 {
     "IsEncrypted": false,
     "Values": {
-      "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-      "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-      "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
-      "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+        "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+        "AzureOpenAI__credential": "managedidentity",
+        "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
+        "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
     }
 }

--- a/samples/embeddings/java/local.settings.json
+++ b/samples/embeddings/java/local.settings.json
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"

--- a/samples/embeddings/java/local.settings.json
+++ b/samples/embeddings/java/local.settings.json
@@ -3,7 +3,9 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }
 }

--- a/samples/embeddings/java/src/main/java/com/azfs/EmbeddingsGenerator.java
+++ b/samples/embeddings/java/src/main/java/com/azfs/EmbeddingsGenerator.java
@@ -31,7 +31,7 @@ public class EmbeddingsGenerator {
                 authLevel = AuthorizationLevel.FUNCTION,
                 route = "embeddings")
             HttpRequestMessage<EmbeddingsRequest> request,
-            @EmbeddingsInput(name = "Embeddings", input = "{RawText}", inputType = InputType.RawText, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") String embeddingsContext,
+            @EmbeddingsInput(name = "Embeddings", input = "{RawText}", inputType = InputType.RawText, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI") String embeddingsContext,
             final ExecutionContext context) {
 
         if (request.getBody() == null) 
@@ -64,7 +64,7 @@ public class EmbeddingsGenerator {
             authLevel = AuthorizationLevel.FUNCTION,
             route = "embeddings-from-file")
         HttpRequestMessage<EmbeddingsRequest> request,
-        @EmbeddingsInput(name = "Embeddings", input = "{FilePath}", inputType = InputType.FilePath, maxChunkLength = 512, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") String embeddingsContext,
+        @EmbeddingsInput(name = "Embeddings", input = "{FilePath}", inputType = InputType.FilePath, maxChunkLength = 512, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI") String embeddingsContext,
         final ExecutionContext context) {
 
         if (request.getBody() == null) 
@@ -97,7 +97,7 @@ public class EmbeddingsGenerator {
             authLevel = AuthorizationLevel.FUNCTION,
             route = "embeddings-from-url")
         HttpRequestMessage<EmbeddingsRequest> request,
-        @EmbeddingsInput(name = "Embeddings", input = "{Url}", inputType = InputType.Url, maxChunkLength = 512, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") String embeddingsContext,
+        @EmbeddingsInput(name = "Embeddings", input = "{Url}", inputType = InputType.Url, maxChunkLength = 512, embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI") String embeddingsContext,
         final ExecutionContext context) {
 
         if (request.getBody() == null) 

--- a/samples/embeddings/javascript/local.settings.json
+++ b/samples/embeddings/javascript/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }
 }

--- a/samples/embeddings/javascript/local.settings.json
+++ b/samples/embeddings/javascript/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"

--- a/samples/embeddings/javascript/src/app.js
+++ b/samples/embeddings/javascript/src/app.js
@@ -4,7 +4,7 @@ const embeddingsHttpInput = input.generic({
     input: '{rawText}',
     inputType: 'RawText',
     type: 'embeddings',
-    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%',
     aiConnectionName: 'AzureOpenAI',
 })
 
@@ -32,7 +32,7 @@ const embeddingsFilePathInput = input.generic({
     inputType: 'FilePath',
     type: 'embeddings',
     maxChunkLength: 512,
-    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%',
     aiConnectionName: 'AzureOpenAI',
 })
 
@@ -60,7 +60,7 @@ const embeddingsUrlInput = input.generic({
     inputType: 'Url',
     type: 'embeddings',
     maxChunkLength: 512,
-    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%',
     aiConnectionName: 'AzureOpenAI',
 })
 

--- a/samples/embeddings/javascript/src/app.js
+++ b/samples/embeddings/javascript/src/app.js
@@ -5,6 +5,7 @@ const embeddingsHttpInput = input.generic({
     inputType: 'RawText',
     type: 'embeddings',
     embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    aiConnectionName: 'AzureOpenAI',
 })
 
 app.http('generateEmbeddings', {
@@ -32,6 +33,7 @@ const embeddingsFilePathInput = input.generic({
     type: 'embeddings',
     maxChunkLength: 512,
     embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    aiConnectionName: 'AzureOpenAI',
 })
 
 app.http('getEmbeddingsFilePath', {
@@ -59,6 +61,7 @@ const embeddingsUrlInput = input.generic({
     type: 'embeddings',
     maxChunkLength: 512,
     embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    aiConnectionName: 'AzureOpenAI',
 })
 
 app.http('getEmbeddingsUrl', {

--- a/samples/embeddings/powershell/GenerateEmbeddings/function.json
+++ b/samples/embeddings/powershell/GenerateEmbeddings/function.json
@@ -21,7 +21,8 @@
       "direction": "in",
       "inputType": "RawText",
       "input": "{rawText}",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/embeddings/powershell/GetEmbeddingsFilePath/function.json
+++ b/samples/embeddings/powershell/GetEmbeddingsFilePath/function.json
@@ -22,7 +22,8 @@
       "inputType": "FilePath",
       "input": "{filePath}",
       "maxChunkLength": 512,
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/embeddings/powershell/GetEmbeddingsURL/function.json
+++ b/samples/embeddings/powershell/GetEmbeddingsURL/function.json
@@ -22,7 +22,8 @@
       "inputType": "Url",
       "input": "{url}",
       "maxChunkLength": 512,
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/embeddings/powershell/local.settings.json
+++ b/samples/embeddings/powershell/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }
 }

--- a/samples/embeddings/powershell/local.settings.json
+++ b/samples/embeddings/powershell/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"

--- a/samples/embeddings/python/function_app.py
+++ b/samples/embeddings/python/function_app.py
@@ -12,6 +12,7 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
     input="{rawText}",
     input_type="rawText",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def generate_embeddings_http_request(
     req: func.HttpRequest, embeddings: str
@@ -35,6 +36,7 @@ def generate_embeddings_http_request(
     input_type="filePath",
     max_chunk_length=512,
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def generate_embeddings_http_file_path(
     req: func.HttpRequest, embeddings: str
@@ -58,6 +60,7 @@ def generate_embeddings_http_file_path(
     input_type="url",
     max_chunk_length=512,
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def generate_embeddings_http_url(
     req: func.HttpRequest, embeddings: str

--- a/samples/embeddings/python/local.settings.json
+++ b/samples/embeddings/python/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",

--- a/samples/embeddings/python/local.settings.json
+++ b/samples/embeddings/python/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }

--- a/samples/embeddings/typescript/local.settings.json
+++ b/samples/embeddings/typescript/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }
 }

--- a/samples/embeddings/typescript/local.settings.json
+++ b/samples/embeddings/typescript/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"

--- a/samples/embeddings/typescript/src/app.ts
+++ b/samples/embeddings/typescript/src/app.ts
@@ -8,7 +8,8 @@ const embeddingsHttpInput = input.generic({
     input: '{rawText}',
     inputType: 'RawText',
     type: 'embeddings',
-    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI',
 })
 
 app.http('generateEmbeddings', {
@@ -39,7 +40,8 @@ const embeddingsFilePathInput = input.generic({
     inputType: 'FilePath',
     type: 'embeddings',
     maxChunkLength: 512,
-    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI',
 })
 
 app.http('getEmbeddingsFilePath', {
@@ -70,7 +72,8 @@ const embeddingsUrlInput = input.generic({
     inputType: 'Url',
     type: 'embeddings',
     maxChunkLength: 512,
-    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%'
+    embeddingsModel: '%EMBEDDING_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI',
 })
 
 app.http('getEmbeddingsUrl', {

--- a/samples/rag-aisearch/csharp-legacy/FilePrompt.cs
+++ b/samples/rag-aisearch/csharp-legacy/FilePrompt.cs
@@ -20,7 +20,7 @@ public static class FilePrompt
     [FunctionName("IngestFile")]
     public static async Task<IActionResult> IngestFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] EmbeddingsRequest req,
-        [EmbeddingsStore("{url}", InputType.Url, "AISearchEndpoint", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
+        [EmbeddingsStore("{url}", InputType.Url, "AISearchEndpoint", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")]
         IAsyncCollector<SearchableDocument> output)
     {
         if (string.IsNullOrWhiteSpace(req.Url))
@@ -42,7 +42,7 @@ public static class FilePrompt
     [FunctionName("PromptFile")]
     public static IActionResult PromptFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] SemanticSearchRequest unused,
-        [SemanticSearch("AISearchEndpoint", "openai-index", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] SemanticSearchContext result)
+        [SemanticSearch("AISearchEndpoint", "openai-index", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] SemanticSearchContext result)
     {
         return new ContentResult { Content = result.Response, ContentType = "text/plain" };
     }

--- a/samples/rag-aisearch/csharp-legacy/local.settings.json
+++ b/samples/rag-aisearch/csharp-legacy/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-aisearch/csharp-legacy/local.settings.json
+++ b/samples/rag-aisearch/csharp-legacy/local.settings.json
@@ -5,7 +5,9 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-aisearch/csharp-ooproc/FilePrompt.cs
+++ b/samples/rag-aisearch/csharp-ooproc/FilePrompt.cs
@@ -67,7 +67,7 @@ public static class FilePrompt
 
     public class EmbeddingsStoreOutputResponse
     {
-        [EmbeddingsStoreOutput("{url}", InputType.Url, "AISearchEndpoint", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
+        [EmbeddingsStoreOutput("{url}", InputType.Url, "AISearchEndpoint", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")]
         public required SearchableDocument SearchableDocument { get; init; }
 
         [HttpResult]
@@ -77,7 +77,7 @@ public static class FilePrompt
     [Function("PromptFile")]
     public static IActionResult PromptFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] SemanticSearchRequest unused,
-        [SemanticSearchInput("AISearchEndpoint", "openai-index", Query = "{prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] SemanticSearchContext result)
+        [SemanticSearchInput("AISearchEndpoint", "openai-index", Query = "{prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] SemanticSearchContext result)
     {
         return new ContentResult { Content = result.Response, ContentType = "text/plain" };
     }

--- a/samples/rag-aisearch/csharp-ooproc/local.settings.json
+++ b/samples/rag-aisearch/csharp-ooproc/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-aisearch/csharp-ooproc/local.settings.json
+++ b/samples/rag-aisearch/csharp-ooproc/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-aisearch/java/local.settings.json
+++ b/samples/rag-aisearch/java/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-aisearch/java/local.settings.json
+++ b/samples/rag-aisearch/java/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-aisearch/java/src/main/java/com/azfs/FilePrompt.java
+++ b/samples/rag-aisearch/java/src/main/java/com/azfs/FilePrompt.java
@@ -35,7 +35,7 @@ public class FilePrompt {
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "AISearchEndpoint", collection = "openai-index",
-                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") OutputBinding<EmbeddingsStoreOutputResponse> output,
+                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI") OutputBinding<EmbeddingsStoreOutputResponse> output,
         final ExecutionContext context) throws URISyntaxException {
 
         if (request.getBody() == null || request.getBody().getUrl() == null)
@@ -79,7 +79,7 @@ public class FilePrompt {
             methods = {HttpMethod.POST},
             authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
-        @SemanticSearch(name = "search", searchConnectionName = "AISearchEndpoint", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
+        @SemanticSearch(name = "search", searchConnectionName = "AISearchEndpoint", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false, aiConnectionName = "AzureOpenAI" ) String semanticSearchContext,
         final ExecutionContext context) {
             String response = new JSONObject(semanticSearchContext).getString("Response");
             return request.createResponseBuilder(HttpStatus.OK)

--- a/samples/rag-aisearch/javascript/local.settings.json
+++ b/samples/rag-aisearch/javascript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-aisearch/javascript/local.settings.json
+++ b/samples/rag-aisearch/javascript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-aisearch/javascript/src/app.js
+++ b/samples/rag-aisearch/javascript/src/app.js
@@ -8,7 +8,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url", 
     storeConnectionName: "AISearchEndpoint", 
     collection: "openai-index", 
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestFile', {
@@ -42,7 +43,8 @@ const semanticSearchInput = input.generic({
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('PromptFile', {

--- a/samples/rag-aisearch/powershell/IngestFile/function.json
+++ b/samples/rag-aisearch/powershell/IngestFile/function.json
@@ -22,7 +22,8 @@
       "inputType": "Url",
       "storeConnectionName": "AISearchEndpoint",
       "collection": "openai-index",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-aisearch/powershell/PromptFile/function.json
+++ b/samples/rag-aisearch/powershell/PromptFile/function.json
@@ -22,7 +22,8 @@
       "collection": "openai-index",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-aisearch/powershell/local.settings.json
+++ b/samples/rag-aisearch/powershell/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",

--- a/samples/rag-aisearch/powershell/local.settings.json
+++ b/samples/rag-aisearch/powershell/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"

--- a/samples/rag-aisearch/python/function_app.py
+++ b/samples/rag-aisearch/python/function_app.py
@@ -14,6 +14,7 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
     store_connection_name="AISearchEndpoint",
     collection="openai-index",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def ingest_file(
     req: func.HttpRequest, requests: func.Out[str]
@@ -43,6 +44,7 @@ def ingest_file(
     collection="openai-index",
     query="{prompt}",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
 )
 def prompt_file(req: func.HttpRequest, result: str) -> func.HttpResponse:

--- a/samples/rag-aisearch/python/local.settings.json
+++ b/samples/rag-aisearch/python/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"

--- a/samples/rag-aisearch/python/local.settings.json
+++ b/samples/rag-aisearch/python/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-aisearch/typescript/local.settings.json
+++ b/samples/rag-aisearch/typescript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-aisearch/typescript/local.settings.json
+++ b/samples/rag-aisearch/typescript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AISearchEndpoint": "https://<resource-name>.search.windows.net",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-aisearch/typescript/src/app.ts
+++ b/samples/rag-aisearch/typescript/src/app.ts
@@ -11,7 +11,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url", 
     storeConnectionName: "AISearchEndpoint", 
     collection: "openai-index", 
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestFile', {
@@ -45,6 +46,7 @@ const semanticSearchInput = input.generic({
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
 

--- a/samples/rag-cosmosdb-nosql/csharp-legacy/FilePrompt.cs
+++ b/samples/rag-cosmosdb-nosql/csharp-legacy/FilePrompt.cs
@@ -20,7 +20,7 @@ public static class FilePrompt
     [FunctionName("IngestFile")]
     public static async Task<IActionResult> IngestFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] EmbeddingsRequest req,
-        [EmbeddingsStore("{url}", InputType.Url, "CosmosDBNoSqlEndpoint", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
+        [EmbeddingsStore("{url}", InputType.Url, "CosmosDBNoSqlEndpoint", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")]
         IAsyncCollector<SearchableDocument> output)
     {
         if (string.IsNullOrWhiteSpace(req.Url))
@@ -42,7 +42,7 @@ public static class FilePrompt
     [FunctionName("PromptFile")]
     public static IActionResult PromptFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] SemanticSearchRequest unused,
-        [SemanticSearch("CosmosDBNoSqlEndpoint", "openai-index", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] SemanticSearchContext result)
+        [SemanticSearch("CosmosDBNoSqlEndpoint", "openai-index", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] SemanticSearchContext result)
     {
         return new ContentResult { Content = result.Response, ContentType = "text/plain" };
     }

--- a/samples/rag-cosmosdb-nosql/csharp-legacy/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/csharp-legacy/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb-nosql/csharp-legacy/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/csharp-legacy/local.settings.json
@@ -5,7 +5,9 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb-nosql/csharp-ooproc/FilePrompt.cs
+++ b/samples/rag-cosmosdb-nosql/csharp-ooproc/FilePrompt.cs
@@ -62,7 +62,8 @@ public static class FilePrompt
             InputType.Url,
             "CosmosDBNoSqlEndpoint",
             "openai-index",
-            EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+            EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+            AIConnectionName = "AzureOpenAI"
         )]
         public required SearchableDocument SearchableDocument { get; init; }
 
@@ -78,7 +79,8 @@ public static class FilePrompt
             "openai-index",
             Query = "{Prompt}",
             ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%",
-            EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+            EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+            AIConnectionName = "AzureOpenAI"
         )]
             SemanticSearchContext result
     )

--- a/samples/rag-cosmosdb-nosql/csharp-ooproc/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/csharp-ooproc/local.settings.json
@@ -4,7 +4,9 @@
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-        "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+        "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+        "AzureOpenAI__credential": "managedidentity",
+        "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
         "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
         "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
     }

--- a/samples/rag-cosmosdb-nosql/csharp-ooproc/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/csharp-ooproc/local.settings.json
@@ -4,7 +4,7 @@
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-        "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+        "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
         "AzureOpenAI__credential": "managedidentity",
         "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
         "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb-nosql/java/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/java/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb-nosql/java/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/java/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb-nosql/java/src/main/java/com/azfs/FilePrompt.java
+++ b/samples/rag-cosmosdb-nosql/java/src/main/java/com/azfs/FilePrompt.java
@@ -35,7 +35,7 @@ public class FilePrompt {
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "CosmosDBNoSqlEndpoint", collection = "openai-index",
-                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") OutputBinding<EmbeddingsStoreOutputResponse> output,
+                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI") OutputBinding<EmbeddingsStoreOutputResponse> output,
         final ExecutionContext context) throws URISyntaxException {
 
         if (request.getBody() == null || request.getBody().getUrl() == null)
@@ -79,7 +79,7 @@ public class FilePrompt {
             methods = {HttpMethod.POST},
             authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
-        @SemanticSearch(name = "search", searchConnectionName = "CosmosDBNoSqlEndpoint", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
+        @SemanticSearch(name = "search", searchConnectionName = "CosmosDBNoSqlEndpoint", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false, aiConnectionName = "AzureOpenAI" ) String semanticSearchContext,
         final ExecutionContext context) {
             String response = new JSONObject(semanticSearchContext).getString("Response");
             return request.createResponseBuilder(HttpStatus.OK)

--- a/samples/rag-cosmosdb-nosql/javascript/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/javascript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb-nosql/javascript/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/javascript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb-nosql/javascript/src/app.js
+++ b/samples/rag-cosmosdb-nosql/javascript/src/app.js
@@ -8,7 +8,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url", 
     storeConnectionName: "CosmosDBNoSqlEndpoint", 
     collection: "openai-index", 
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestFile', {
@@ -42,7 +43,8 @@ const semanticSearchInput = input.generic({
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('PromptFile', {

--- a/samples/rag-cosmosdb-nosql/powershell/IngestFile/function.json
+++ b/samples/rag-cosmosdb-nosql/powershell/IngestFile/function.json
@@ -22,7 +22,8 @@
       "inputType": "Url",
       "storeConnectionName": "CosmosDBNoSqlEndpoint",
       "collection": "openai-index",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-cosmosdb-nosql/powershell/PromptFile/function.json
+++ b/samples/rag-cosmosdb-nosql/powershell/PromptFile/function.json
@@ -22,7 +22,8 @@
       "collection": "openai-index",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-cosmosdb-nosql/powershell/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/powershell/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb-nosql/powershell/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/powershell/local.settings.json
@@ -5,7 +5,9 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb-nosql/python/function_app.py
+++ b/samples/rag-cosmosdb-nosql/python/function_app.py
@@ -14,6 +14,7 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
     store_connection_name="CosmosDBNoSqlEndpoint",
     collection="openai-index",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def ingest_file(req: func.HttpRequest, requests: func.Out[str]) -> func.HttpResponse:
     user_message = req.get_json()
@@ -41,6 +42,7 @@ def ingest_file(req: func.HttpRequest, requests: func.Out[str]) -> func.HttpResp
     collection="openai-index",
     query="{prompt}",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
 )
 def prompt_file(req: func.HttpRequest, result: str) -> func.HttpResponse:

--- a/samples/rag-cosmosdb-nosql/python/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/python/local.settings.json
@@ -5,7 +5,7 @@
         "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
         "FUNCTIONS_WORKER_RUNTIME": "python",
         "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-        "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+        "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
         "AzureOpenAI__credential": "managedidentity",
         "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
         "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb-nosql/python/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/python/local.settings.json
@@ -5,7 +5,9 @@
         "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
         "FUNCTIONS_WORKER_RUNTIME": "python",
         "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-        "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+        "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+        "AzureOpenAI__credential": "managedidentity",
+        "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
         "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
         "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",
         "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"

--- a/samples/rag-cosmosdb-nosql/typescript/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/typescript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb-nosql/typescript/local.settings.json
+++ b/samples/rag-cosmosdb-nosql/typescript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBNoSqlEndpoint": "https://<resource-name>.documents.azure.com:443/",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb-nosql/typescript/src/app.ts
+++ b/samples/rag-cosmosdb-nosql/typescript/src/app.ts
@@ -11,7 +11,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url", 
     storeConnectionName: "CosmosDBNoSqlEndpoint", 
     collection: "openai-index", 
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestFile', {
@@ -45,6 +46,7 @@ const semanticSearchInput = input.generic({
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
 

--- a/samples/rag-cosmosdb/csharp-legacy/FilePrompt.cs
+++ b/samples/rag-cosmosdb/csharp-legacy/FilePrompt.cs
@@ -20,7 +20,7 @@ public static class FilePrompt
     [FunctionName("IngestFile")]
     public static async Task<IActionResult> IngestFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] EmbeddingsRequest req,
-        [EmbeddingsStore("{url}", InputType.Url, "CosmosDBMongoVCoreConnectionString", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
+        [EmbeddingsStore("{url}", InputType.Url, "CosmosDBMongoVCoreConnectionString", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")]
         IAsyncCollector<SearchableDocument> output)
     {
         if (string.IsNullOrWhiteSpace(req.Url))
@@ -42,7 +42,7 @@ public static class FilePrompt
     [FunctionName("PromptFile")]
     public static IActionResult PromptFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] SemanticSearchRequest unused,
-        [SemanticSearch("CosmosDBMongoVCoreConnectionString", "openai-index", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] SemanticSearchContext result)
+        [SemanticSearch("CosmosDBMongoVCoreConnectionString", "openai-index", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] SemanticSearchContext result)
     {
         return new ContentResult { Content = result.Response, ContentType = "text/plain" };
     }

--- a/samples/rag-cosmosdb/csharp-legacy/local.settings.json
+++ b/samples/rag-cosmosdb/csharp-legacy/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb/csharp-legacy/local.settings.json
+++ b/samples/rag-cosmosdb/csharp-legacy/local.settings.json
@@ -5,7 +5,9 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb/csharp-ooproc/FilePrompt.cs
+++ b/samples/rag-cosmosdb/csharp-ooproc/FilePrompt.cs
@@ -66,7 +66,7 @@ public static class FilePrompt
 
     public class EmbeddingsStoreOutputResponse
     {
-        [EmbeddingsStoreOutput("{url}", InputType.Url, "CosmosDBMongoVCoreConnectionString", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
+        [EmbeddingsStoreOutput("{url}", InputType.Url, "CosmosDBMongoVCoreConnectionString", "openai-index", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")]
         public required SearchableDocument SearchableDocument { get; init; }
 
         [HttpResult]
@@ -76,7 +76,7 @@ public static class FilePrompt
     [Function("PromptFile")]
     public static IActionResult PromptFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] SemanticSearchRequest unused,
-        [SemanticSearchInput("CosmosDBMongoVCoreConnectionString", "openai-index", Query = "{prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] SemanticSearchContext result)
+        [SemanticSearchInput("CosmosDBMongoVCoreConnectionString", "openai-index", Query = "{prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] SemanticSearchContext result)
     {
         return new ContentResult { Content = result.Response, ContentType = "text/plain" };
     }

--- a/samples/rag-cosmosdb/csharp-ooproc/local.settings.json
+++ b/samples/rag-cosmosdb/csharp-ooproc/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb/csharp-ooproc/local.settings.json
+++ b/samples/rag-cosmosdb/csharp-ooproc/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb/java/local.settings.json
+++ b/samples/rag-cosmosdb/java/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb/java/local.settings.json
+++ b/samples/rag-cosmosdb/java/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb/java/src/main/java/com/azfs/FilePrompt.java
+++ b/samples/rag-cosmosdb/java/src/main/java/com/azfs/FilePrompt.java
@@ -30,7 +30,7 @@ public class FilePrompt {
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "CosmosDBMongoVCoreConnectionString", collection = "openai-index",
-                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") OutputBinding<EmbeddingsStoreOutputResponse> output,
+                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI") OutputBinding<EmbeddingsStoreOutputResponse> output,
         final ExecutionContext context) throws URISyntaxException {
 
         if (request.getBody() == null || request.getBody().getUrl() == null)
@@ -74,7 +74,7 @@ public class FilePrompt {
             methods = {HttpMethod.POST},
             authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
-        @SemanticSearch(name = "search", searchConnectionName = "CosmosDBMongoVCoreConnectionString", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
+        @SemanticSearch(name = "search", searchConnectionName = "CosmosDBMongoVCoreConnectionString", collection = "openai-index", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false, aiConnectionName = "AzureOpenAI" ) String semanticSearchContext,
         final ExecutionContext context) {
             String response = new JSONObject(semanticSearchContext).getString("Response");
             return request.createResponseBuilder(HttpStatus.OK)

--- a/samples/rag-cosmosdb/javascript/local.settings.json
+++ b/samples/rag-cosmosdb/javascript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb/javascript/local.settings.json
+++ b/samples/rag-cosmosdb/javascript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb/javascript/src/app.js
+++ b/samples/rag-cosmosdb/javascript/src/app.js
@@ -8,7 +8,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url", 
     storeConnectionName: "CosmosDBMongoVCoreConnectionString", 
     collection: "openai-index", 
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestFile', {
@@ -42,7 +43,8 @@ const semanticSearchInput = input.generic({
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('PromptFile', {

--- a/samples/rag-cosmosdb/powershell/IngestFile/function.json
+++ b/samples/rag-cosmosdb/powershell/IngestFile/function.json
@@ -22,7 +22,8 @@
       "inputType": "Url",
       "storeConnectionName": "CosmosDBMongoVCoreConnectionString",
       "collection": "openai-index",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-cosmosdb/powershell/PromptFile/function.json
+++ b/samples/rag-cosmosdb/powershell/PromptFile/function.json
@@ -22,7 +22,8 @@
       "collection": "openai-index",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-cosmosdb/powershell/local.settings.json
+++ b/samples/rag-cosmosdb/powershell/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb/powershell/local.settings.json
+++ b/samples/rag-cosmosdb/powershell/local.settings.json
@@ -5,7 +5,9 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb/python/function_app.py
+++ b/samples/rag-cosmosdb/python/function_app.py
@@ -14,6 +14,7 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
     store_connection_name="CosmosDBMongoVCoreConnectionString",
     collection="openai-index",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def ingest_file(
     req: func.HttpRequest, requests: func.Out[str]
@@ -43,6 +44,7 @@ def ingest_file(
     collection="openai-index",
     query="{prompt}",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
 )
 def prompt_file(req: func.HttpRequest, result: str) -> func.HttpResponse:

--- a/samples/rag-cosmosdb/python/local.settings.json
+++ b/samples/rag-cosmosdb/python/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"

--- a/samples/rag-cosmosdb/python/local.settings.json
+++ b/samples/rag-cosmosdb/python/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb/typescript/local.settings.json
+++ b/samples/rag-cosmosdb/typescript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-ada-002"
   }

--- a/samples/rag-cosmosdb/typescript/local.settings.json
+++ b/samples/rag-cosmosdb/typescript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "CosmosDBMongoVCoreConnectionString": "",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-cosmosdb/typescript/src/app.ts
+++ b/samples/rag-cosmosdb/typescript/src/app.ts
@@ -11,7 +11,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url", 
     storeConnectionName: "CosmosDBMongoVCoreConnectionString", 
     collection: "openai-index", 
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestFile', {
@@ -45,6 +46,7 @@ const semanticSearchInput = input.generic({
     collection: "openai-index",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
 

--- a/samples/rag-kusto/csharp-legacy/FilePrompt.cs
+++ b/samples/rag-kusto/csharp-legacy/FilePrompt.cs
@@ -20,7 +20,7 @@ public static class FilePrompt
     [FunctionName("IngestFile")]
     public static async Task<IActionResult> IngestFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] EmbeddingsRequest req,
-        [EmbeddingsStore("{url}", InputType.Url, "KustoConnectionString", "Documents", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
+        [EmbeddingsStore("{url}", InputType.Url, "KustoConnectionString", "Documents", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")]
         IAsyncCollector<SearchableDocument> output)
     {
         if (string.IsNullOrWhiteSpace(req.Url))
@@ -42,7 +42,7 @@ public static class FilePrompt
     [FunctionName("PromptFile")]
     public static IActionResult PromptFile(
         [HttpTrigger(AuthorizationLevel.Function, "post")] SemanticSearchRequest unused,
-        [SemanticSearch("KustoConnectionString", "Documents", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] SemanticSearchContext result)
+        [SemanticSearch("KustoConnectionString", "Documents", Query = "{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] SemanticSearchContext result)
     {
         return new ContentResult { Content = result.Response, ContentType = "text/plain" };
     }

--- a/samples/rag-kusto/csharp-legacy/local.settings.json
+++ b/samples/rag-kusto/csharp-legacy/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-kusto/csharp-legacy/local.settings.json
+++ b/samples/rag-kusto/csharp-legacy/local.settings.json
@@ -5,7 +5,9 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small"
   }

--- a/samples/rag-kusto/csharp-ooproc/EmailPromptDemo.cs
+++ b/samples/rag-kusto/csharp-ooproc/EmailPromptDemo.cs
@@ -66,7 +66,7 @@ public class EmailPromptDemo
     }
     public class EmbeddingsStoreOutputResponse
     {
-        [EmbeddingsStoreOutput("{url}", InputType.Url, "KustoConnectionString", "Documents", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")]
+        [EmbeddingsStoreOutput("{url}", InputType.Url, "KustoConnectionString", "Documents", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")]
         public required SearchableDocument SearchableDocument { get; init; }
 
         [HttpResult]
@@ -76,7 +76,7 @@ public class EmailPromptDemo
     [Function("PromptEmail")]
     public IActionResult PromptEmail(
         [HttpTrigger(AuthorizationLevel.Function, "post")] SemanticSearchRequest unused,
-        [SemanticSearchInput("KustoConnectionString", "Documents", Query = "{prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%")] SemanticSearchContext result)
+        [SemanticSearchInput("KustoConnectionString", "Documents", Query = "{prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", EmbeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] SemanticSearchContext result)
     {
         return new ContentResult { Content = result.Response, ContentType = "text/plain" };
     }

--- a/samples/rag-kusto/csharp-ooproc/local.settings.json
+++ b/samples/rag-kusto/csharp-ooproc/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-kusto/csharp-ooproc/local.settings.json
+++ b/samples/rag-kusto/csharp-ooproc/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small"
   }

--- a/samples/rag-kusto/java/local.settings.json
+++ b/samples/rag-kusto/java/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-kusto/java/local.settings.json
+++ b/samples/rag-kusto/java/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small"
   }

--- a/samples/rag-kusto/java/src/main/java/com/azfs/EmailPromptDemo.java
+++ b/samples/rag-kusto/java/src/main/java/com/azfs/EmailPromptDemo.java
@@ -36,7 +36,7 @@ public class EmailPromptDemo {
             HttpRequestMessage<EmbeddingsRequest> request,
         @EmbeddingsStoreOutput(name="EmbeddingsStoreOutput", input = "{url}", inputType = InputType.Url,
                 storeConnectionName = "KustoConnectionString", collection = "Documents",
-                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%") OutputBinding<EmbeddingsStoreOutputResponse> output,
+                embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", aiConnectionName = "AzureOpenAI") OutputBinding<EmbeddingsStoreOutputResponse> output,
         final ExecutionContext context) throws URISyntaxException {
 
         if (request.getBody() == null || request.getBody().getUrl() == null)
@@ -80,7 +80,7 @@ public class EmailPromptDemo {
             methods = {HttpMethod.POST},
             authLevel = AuthorizationLevel.FUNCTION)
             HttpRequestMessage<SemanticSearchRequest> request,
-        @SemanticSearch(name = "search", searchConnectionName = "KustoConnectionString", collection = "Documents", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false ) String semanticSearchContext,
+        @SemanticSearch(name = "search", searchConnectionName = "KustoConnectionString", collection = "Documents", query = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", embeddingsModel = "%EMBEDDING_MODEL_DEPLOYMENT_NAME%", isReasoningModel = false, aiConnectionName = "AzureOpenAI" ) String semanticSearchContext,
         final ExecutionContext context) {
             String response = new JSONObject(semanticSearchContext).getString("Response");
             return request.createResponseBuilder(HttpStatus.OK)

--- a/samples/rag-kusto/javascript/local.settings.json
+++ b/samples/rag-kusto/javascript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small"
   }

--- a/samples/rag-kusto/javascript/local.settings.json
+++ b/samples/rag-kusto/javascript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-kusto/javascript/src/app.js
+++ b/samples/rag-kusto/javascript/src/app.js
@@ -8,7 +8,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url",
     connectionName: "KustoConnectionString",
     collection: "Documents",
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestEmail', {
@@ -42,7 +43,8 @@ const semanticSearchInput = input.generic({
     collection: "Documents",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('PromptEmail', {

--- a/samples/rag-kusto/powershell/IngestEmail/function.json
+++ b/samples/rag-kusto/powershell/IngestEmail/function.json
@@ -22,7 +22,8 @@
       "inputType": "Url",
       "storeConnectionName": "KustoConnectionString",
       "collection": "Documents",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-kusto/powershell/PromptEmail/function.json
+++ b/samples/rag-kusto/powershell/PromptEmail/function.json
@@ -22,7 +22,8 @@
       "collection": "Documents",
       "query": "{prompt}",
       "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",
-      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+      "embeddingsModel": "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/rag-kusto/powershell/local.settings.json
+++ b/samples/rag-kusto/powershell/local.settings.json
@@ -5,7 +5,9 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small"
   }

--- a/samples/rag-kusto/powershell/local.settings.json
+++ b/samples/rag-kusto/powershell/local.settings.json
@@ -5,7 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-kusto/python/function_app.py
+++ b/samples/rag-kusto/python/function_app.py
@@ -14,6 +14,7 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
     store_connection_name="KustoConnectionString",
     collection="Documents",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def ingest_email(
     req: func.HttpRequest, requests: func.Out[str]
@@ -43,6 +44,7 @@ def ingest_email(
     collection="Documents",
     query="{prompt}",
     embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
 )
 def prompt_email(req: func.HttpRequest, result: str) -> func.HttpResponse:

--- a/samples/rag-kusto/python/local.settings.json
+++ b/samples/rag-kusto/python/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"

--- a/samples/rag-kusto/python/local.settings.json
+++ b/samples/rag-kusto/python/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-kusto/typescript/local.settings.json
+++ b/samples/rag-kusto/typescript/local.settings.json
@@ -5,7 +5,9 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "EMBEDDING_MODEL_DEPLOYMENT_NAME": "text-embedding-3-small"
   }

--- a/samples/rag-kusto/typescript/local.settings.json
+++ b/samples/rag-kusto/typescript/local.settings.json
@@ -5,7 +5,7 @@
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "KustoConnectionString": "Data Source=https://YOUR-CLUSTER-HOSTNAME;Initial Catalog=YOUR-DATABASE-NAME;Fed=True",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/rag-kusto/typescript/src/app.ts
+++ b/samples/rag-kusto/typescript/src/app.ts
@@ -11,7 +11,8 @@ const embeddingsStoreOutput = output.generic({
     inputType: "url",
     connectionName: "KustoConnectionString",
     collection: "Documents",
-    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
+    embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
 });
 
 app.http('IngestEmail', {
@@ -45,6 +46,7 @@ const semanticSearchInput = input.generic({
     collection: "Documents",
     query: "{prompt}",
     chatModel: "%CHAT_MODEL_DEPLOYMENT_NAME%",
+    aiConnectionName: 'AzureOpenAI',
     embeddingsModel: "%EMBEDDING_MODEL_DEPLOYMENT_NAME%"
 });
 

--- a/samples/textcompletion/csharp-legacy/TextCompletionLegacy.cs
+++ b/samples/textcompletion/csharp-legacy/TextCompletionLegacy.cs
@@ -24,7 +24,7 @@ public static class TextCompletionLegacy
     [FunctionName(nameof(WhoIs))]
     public static IActionResult WhoIs(
         [HttpTrigger(AuthorizationLevel.Function, Route = "whois/{name}")] HttpRequest req,
-        [TextCompletion("Who is {name}?", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%")] TextCompletionResponse response)
+        [TextCompletion("Who is {name}?", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] TextCompletionResponse response)
     {
         return new OkObjectResult(response.Content);
     }
@@ -36,7 +36,7 @@ public static class TextCompletionLegacy
     [FunctionName(nameof(GenericCompletion))]
     public static IActionResult GenericCompletion(
         [HttpTrigger(AuthorizationLevel.Function, "post")] PromptPayload payload,
-        [TextCompletion("{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%")] TextCompletionResponse response,
+        [TextCompletion("{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] TextCompletionResponse response,
         ILogger log)
     {
         string text = response.Content;

--- a/samples/textcompletion/csharp-legacy/local.settings.json
+++ b/samples/textcompletion/csharp-legacy/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/textcompletion/csharp-legacy/local.settings.json
+++ b/samples/textcompletion/csharp-legacy/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_INPROC_NET8_ENABLED": "1",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/textcompletion/csharp-ooproc/TextCompletions.cs
+++ b/samples/textcompletion/csharp-ooproc/TextCompletions.cs
@@ -23,7 +23,7 @@ public static class TextCompletions
     [Function(nameof(WhoIs))]
     public static IActionResult WhoIs(
         [HttpTrigger(AuthorizationLevel.Function, Route = "whois/{name}")] HttpRequestData req,
-        [TextCompletionInput("Who is {name}?", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%")] TextCompletionResponse response)
+        [TextCompletionInput("Who is {name}?", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] TextCompletionResponse response)
     {
         return new OkObjectResult(response.Content);
     }
@@ -35,7 +35,7 @@ public static class TextCompletions
     [Function(nameof(GenericCompletion))]
     public static IActionResult GenericCompletion(
         [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req,
-        [TextCompletionInput("{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%")] TextCompletionResponse response,
+        [TextCompletionInput("{Prompt}", ChatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", AIConnectionName = "AzureOpenAI")] TextCompletionResponse response,
         ILogger log)
     {
         string text = response.Content;

--- a/samples/textcompletion/csharp-ooproc/local.settings.json
+++ b/samples/textcompletion/csharp-ooproc/local.settings.json
@@ -3,7 +3,9 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/textcompletion/csharp-ooproc/local.settings.json
+++ b/samples/textcompletion/csharp-ooproc/local.settings.json
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/textcompletion/java/local.settings.json
+++ b/samples/textcompletion/java/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "java",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/textcompletion/java/local.settings.json
+++ b/samples/textcompletion/java/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "java",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/textcompletion/java/src/main/java/com/azfs/TextCompletions.java
+++ b/samples/textcompletion/java/src/main/java/com/azfs/TextCompletions.java
@@ -37,7 +37,7 @@ public class TextCompletions {
             route = "whois/{name}") 
             HttpRequestMessage<Optional<String>> request,
         @BindingName("name") String name,
-        @TextCompletion(prompt = "Who is {name}?", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", name = "response", isReasoningModel = false) TextCompletionResponse response,
+        @TextCompletion(prompt = "Who is {name}?", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", name = "response", isReasoningModel = false, aiConnectionName = "AzureOpenAI") TextCompletionResponse response,
         final ExecutionContext context) {
         return request.createResponseBuilder(HttpStatus.OK)
             .header("Content-Type", "application/json")
@@ -56,7 +56,7 @@ public class TextCompletions {
             methods = {HttpMethod.POST},
             authLevel = AuthorizationLevel.FUNCTION) 
             HttpRequestMessage<Optional<String>> request,
-        @TextCompletion(prompt = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", name = "response", isReasoningModel = false) TextCompletionResponse response,
+        @TextCompletion(prompt = "{prompt}", chatModel = "%CHAT_MODEL_DEPLOYMENT_NAME%", name = "response", isReasoningModel = false, aiConnectionName = "AzureOpenAI") TextCompletionResponse response,
         final ExecutionContext context) {
         return request.createResponseBuilder(HttpStatus.OK)
             .header("Content-Type", "application/json")

--- a/samples/textcompletion/javascript/local.settings.json
+++ b/samples/textcompletion/javascript/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/textcompletion/javascript/local.settings.json
+++ b/samples/textcompletion/javascript/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/textcompletion/javascript/src/functions/whois.js
+++ b/samples/textcompletion/javascript/src/functions/whois.js
@@ -5,7 +5,8 @@ const openAICompletionInput = input.generic({
     prompt: 'Who is {name}?',
     maxTokens: '100',
     type: 'textCompletion',
-    chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%'
+    chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI'
 })
 
 app.http('whois', {

--- a/samples/textcompletion/powershell/WhoIs/function.json
+++ b/samples/textcompletion/powershell/WhoIs/function.json
@@ -21,7 +21,8 @@
       "name": "TextCompletionResponse",
       "prompt": "Who is {name}?",
       "maxTokens": "100",
-      "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%"
+      "chatModel": "%CHAT_MODEL_DEPLOYMENT_NAME%",
+      "aiConnectionName": "AzureOpenAI"
     }
   ]
 }

--- a/samples/textcompletion/powershell/local.settings.json
+++ b/samples/textcompletion/powershell/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/textcompletion/powershell/local.settings.json
+++ b/samples/textcompletion/powershell/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.2",
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/textcompletion/python/function_app.py
+++ b/samples/textcompletion/python/function_app.py
@@ -10,6 +10,7 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
     prompt="Who is {name}?",
     max_tokens="100",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def whois(req: func.HttpRequest, response: str) -> func.HttpResponse:
     response_json = json.loads(response)
@@ -21,6 +22,7 @@ def whois(req: func.HttpRequest, response: str) -> func.HttpResponse:
     arg_name="response",
     prompt="{Prompt}",
     chat_model="%CHAT_MODEL_DEPLOYMENT_NAME%",
+    ai_connection_name="AzureOpenAI",
 )
 def genericcompletion(
     req: func.HttpRequest,

--- a/samples/textcompletion/python/local.settings.json
+++ b/samples/textcompletion/python/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",

--- a/samples/textcompletion/python/local.settings.json
+++ b/samples/textcompletion/python/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }

--- a/samples/textcompletion/typescript/local.settings.json
+++ b/samples/textcompletion/typescript/local.settings.json
@@ -4,7 +4,9 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AZURE_OPENAI_ENDPOINT": "Placeholder for the Azure OpenAI endpoint value",
+    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__credential": "managedidentity",
+    "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"
   }
 }

--- a/samples/textcompletion/typescript/local.settings.json
+++ b/samples/textcompletion/typescript/local.settings.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "AzureOpenAI__endpoint": "https://<your-resource>.openai.azure.com/",
+    "AzureOpenAI__endpoint": "<Placeholder for the Azure OpenAI endpoint value>",
     "AzureOpenAI__credential": "managedidentity",
     "AzureOpenAI__clientId": "<user-assigned-managed-identity-client-id>",
     "CHAT_MODEL_DEPLOYMENT_NAME": "gpt-3.5-turbo"

--- a/samples/textcompletion/typescript/src/functions/whois.ts
+++ b/samples/textcompletion/typescript/src/functions/whois.ts
@@ -5,7 +5,8 @@ const openAICompletionInput = input.generic({
     prompt: 'Who is {name}?',
     maxTokens: '100',
     type: 'textCompletion',
-    chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%'
+    chatModel: '%CHAT_MODEL_DEPLOYMENT_NAME%',
+    aiConnectionName: 'AzureOpenAI'
 })
 
 app.http('whois', {


### PR DESCRIPTION
The samples from this repo are being used in OpenAI extension documentation (tutorial and references). We need to move authentication to Microsoft Entra ID with managed identities, which requires use of the new `AIConnectionName` setting and APIs for connections.
  
Here are the checks that Copilot ran for me on my changes in this PR:

| Check | Result |
|---|---|
| **C# build** (`dotnet build`) | Build succeeded, 0 errors |
| **TypeScript** (`tsc --noEmit`) | 3 samples checked, all pass |
| **JavaScript** (`node --check`) | All 10 files pass |
| **Python** (`py_compile`) | All 11 files pass |
| **PowerShell** (`function.json` JSON parse) | All 20 files valid |
| **local.settings.json** (JSON parse) | All 56 files valid |
| **Semantic: missing `aiConnectionName`** | No files with model bindings are missing it |