### PR TITLE
Onboard dependency restores to Central Feed Service

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@isaacs:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/eng/ci/templates/build-java-samples.yml
+++ b/eng/ci/templates/build-java-samples.yml
@@ -1,6 +1,11 @@
 jobs:
   - job: BuildJavaSamples
     steps:
+      - task: npmAuthenticate@0
+        displayName: 'Authenticate npm feed'
+        inputs:
+          workingFile: '$(System.DefaultWorkingDirectory)/.npmrc'
+
       - script: npm install -g azure-functions-core-tools
         displayName: 'Install Azure Functions Core Tools'
 

--- a/eng/ci/templates/build-java-samples.yml
+++ b/eng/ci/templates/build-java-samples.yml
@@ -8,6 +8,8 @@ jobs:
 
       - script: npm install -g azure-functions-core-tools
         displayName: 'Install Azure Functions Core Tools'
+        env:
+          NPM_CONFIG_USERCONFIG: '$(System.DefaultWorkingDirectory)/.npmrc'
 
       - task: Maven@3
         displayName: Build Chat Sample

--- a/eng/ci/templates/build-local.yml
+++ b/eng/ci/templates/build-local.yml
@@ -11,6 +11,9 @@ jobs:
         inputs:
           version: '8.x'
 
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate NuGet feeds'
+
       - script: |
           mkdir "$(System.DefaultWorkingDirectory)/NuGetPackagesLocal"
         displayName: Create new directory
@@ -65,7 +68,8 @@ jobs:
 
       - script: |
           dir "$(System.DefaultWorkingDirectory)/NuGetPackagesLocal"
-          dotnet nuget add source $(System.DefaultWorkingDirectory)/NuGetPackagesLocal --configfile  %appdata%/NuGet/NuGet.Config
-          dotnet nuget list source --configfile  %appdata%/NuGet/NuGet.Config
-          dotnet build --configuration $(config) /p:WebJobsVersion=$(fakeWebJobsPackageVersion) /p:Version=$(fakeWebJobsPackageVersion) /p:AzureAISearchVersion=$(fakeWebJobsPackageVersion) /p:KustoVersion=$(fakeWebJobsPackageVersion) /p:CosmosDBSearchVersion=$(fakeWebJobsPackageVersion) /p:CosmosDBNoSqlSearchVersion=$(fakeWebJobsPackageVersion) --configfile %appdata%/NuGet/NuGet.Config
+          copy "$(System.DefaultWorkingDirectory)\nuget.config" "$(Agent.TempDirectory)\NuGet.Local.config"
+          dotnet nuget add source "$(System.DefaultWorkingDirectory)\NuGetPackagesLocal" --configfile "$(Agent.TempDirectory)\NuGet.Local.config"
+          dotnet nuget list source --configfile "$(Agent.TempDirectory)\NuGet.Local.config"
+          dotnet build --configuration $(config) /p:WebJobsVersion=$(fakeWebJobsPackageVersion) /p:Version=$(fakeWebJobsPackageVersion) /p:AzureAISearchVersion=$(fakeWebJobsPackageVersion) /p:KustoVersion=$(fakeWebJobsPackageVersion) /p:CosmosDBSearchVersion=$(fakeWebJobsPackageVersion) /p:CosmosDBNoSqlSearchVersion=$(fakeWebJobsPackageVersion) --configfile "$(Agent.TempDirectory)\NuGet.Local.config"
         displayName: Build from local NuGet packages

--- a/eng/ci/templates/build-nuget.yml
+++ b/eng/ci/templates/build-nuget.yml
@@ -19,6 +19,9 @@ jobs:
           version: '2.1.x'
           performMultiLevelLookup: true
 
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate NuGet feeds'
+
       - task: DotNetCoreCLI@2
         displayName: 'Dotnet Restore'
         inputs:

--- a/eng/ci/templates/run-integration-tests.yml
+++ b/eng/ci/templates/run-integration-tests.yml
@@ -12,6 +12,9 @@ jobs:
         inputs:
           version: '8.x'
 
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate NuGet feeds'
+
       - script: |
           mkdir "$(System.DefaultWorkingDirectory)/NuGetPackagesLocal"
         displayName: Create new directory
@@ -54,9 +57,10 @@ jobs:
 
       - script: |
           dir "$(System.DefaultWorkingDirectory)/NuGetPackagesLocal"
-          dotnet nuget add source $(System.DefaultWorkingDirectory)/NuGetPackagesLocal --configfile  %appdata%/NuGet/NuGet.Config
-          dotnet nuget list source --configfile  %appdata%/NuGet/NuGet.Config
-          dotnet build --configuration $(config) /p:WebJobsVersion=$(fakeWebJobsPackageVersion) /p:Version=$(fakeWebJobsPackageVersion) /p:AzureAISearchVersion=$(fakeWebJobsPackageVersion) /p:KustoVersion=$(fakeWebJobsPackageVersion) -p:CosmosDBSearchVersion=$(fakeWebJobsPackageVersion) -p:CosmosDBNoSqlSearchVersion=$(fakeWebJobsPackageVersion) --configfile %appdata%/NuGet/NuGet.Config
+          copy "$(System.DefaultWorkingDirectory)\nuget.config" "$(Agent.TempDirectory)\NuGet.Local.config"
+          dotnet nuget add source "$(System.DefaultWorkingDirectory)\NuGetPackagesLocal" --configfile "$(Agent.TempDirectory)\NuGet.Local.config"
+          dotnet nuget list source --configfile "$(Agent.TempDirectory)\NuGet.Local.config"
+          dotnet build --configuration $(config) /p:WebJobsVersion=$(fakeWebJobsPackageVersion) /p:Version=$(fakeWebJobsPackageVersion) /p:AzureAISearchVersion=$(fakeWebJobsPackageVersion) /p:KustoVersion=$(fakeWebJobsPackageVersion) -p:CosmosDBSearchVersion=$(fakeWebJobsPackageVersion) -p:CosmosDBNoSqlSearchVersion=$(fakeWebJobsPackageVersion) --configfile "$(Agent.TempDirectory)\NuGet.Local.config"
         displayName: Build from local NuGet packages
 
       - task: DotNetCoreCLI@2

--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- route NuGet restores through the `public/upstream-public` CFS proxy
- authenticate all Azure Pipelines jobs with explicit or implicit NuGet restores
- route the repository-owned Azure Functions Core Tools global npm install through CFS, bind it to the authenticated `.npmrc` with `NPM_CONFIG_USERCONFIG`, and map its resolved `@isaacs` and `@types` production scopes
- preserve the CFS source when integration jobs add locally built NuGet packages

## Scope
Customer-facing samples, templates, lockfile URLs, Python requirements, and Maven project configuration remain unchanged. The audit found no repository-owned Python install job requiring `PipAuthenticate@1`.

## Validation
- `dotnet restore OpenAI-Extension.sln --configfile nuget.config`
- `dotnet test tests/UnitTests/WebJobsOpenAIUnitTests.csproj --configuration Release --no-restore` (36 passed)
- CFS source and forbidden-setting assertions
- authentication ordering assertions for every affected pipeline job
- Core Tools 4.12.1 production graph audit (38 packages; scopes: `@isaacs`, `@types`)
- `NPM_CONFIG_USERCONFIG` registry and scope resolution with a space-containing config path
- temporary local NuGet source configuration check
- Windows command-boundary validation with repository, agent-temp, NuGet source, and npm config paths containing spaces
- npm package metadata query through the CFS registry