### PR TITLE
Onboard Maven dependency restores to Central Feed Service

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF endings so they remain executable from bash on
+# Windows (git-bash, WSL) as well as Linux and macOS build agents.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -422,3 +422,9 @@ local.settings.json
 # Java files
 target/
 .idea/
+
+# Maven credential provider extension. This is a per-developer opt-in for
+# authenticating to Azure Artifacts and must never be committed: the extension
+# exits when it detects a build context, and committing it would impose an
+# authenticated restore on anonymous consumers. CI uses MavenAuthenticate@0.
+.mvn/

--- a/eng/ci/templates/build-java-library.yml
+++ b/eng/ci/templates/build-java-library.yml
@@ -7,6 +7,12 @@ jobs:
           artifactName: drop-java-library
           condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
     steps:
+      - task: MavenAuthenticate@0
+        displayName: Authenticate Maven feed
+        inputs:
+          # Must match the <id> of the repositories declared in the pom.xml files.
+          artifactsFeeds: central
+
       - task: Maven@3
         displayName: Build library
         inputs:

--- a/eng/ci/templates/build-java-library.yml
+++ b/eng/ci/templates/build-java-library.yml
@@ -7,11 +7,20 @@ jobs:
           artifactName: drop-java-library
           condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
     steps:
+      # Maven resolves plugins and extensions before a pom's <repositories> are honored, so the
+      # feed has to be configured as a mirror too. Must run before MavenAuthenticate@0, which
+      # edits this same file to add credentials.
+      - powershell: |
+          $m2 = Join-Path $HOME '.m2'
+          New-Item -ItemType Directory -Path $m2 -Force | Out-Null
+          Copy-Item '$(Build.SourcesDirectory)/settings.xml' (Join-Path $m2 'settings.xml') -Force
+        displayName: Install Maven settings.xml
+
       - task: MavenAuthenticate@0
         displayName: Authenticate Maven feed
         inputs:
-          # Must match the <id> of the repositories declared in the pom.xml files.
-          artifactsFeeds: central
+          # Azure Artifacts feed name, which must match the <id> of the mirror in settings.xml.
+          artifactsFeeds: upstream-public
 
       - task: Maven@3
         displayName: Build library

--- a/eng/ci/templates/build-java-samples.yml
+++ b/eng/ci/templates/build-java-samples.yml
@@ -1,6 +1,12 @@
 jobs:
   - job: BuildJavaSamples
     steps:
+      - task: MavenAuthenticate@0
+        displayName: 'Authenticate Maven feed'
+        inputs:
+          # Must match the <id> of the repositories declared in the pom.xml files.
+          artifactsFeeds: central
+
       - task: npmAuthenticate@0
         displayName: 'Authenticate npm feed'
         inputs:

--- a/eng/ci/templates/build-java-samples.yml
+++ b/eng/ci/templates/build-java-samples.yml
@@ -1,11 +1,20 @@
 jobs:
   - job: BuildJavaSamples
     steps:
+      # Maven resolves plugins and extensions before a pom's <repositories> are honored, so the
+      # feed has to be configured as a mirror too. Must run before MavenAuthenticate@0, which
+      # edits this same file to add credentials.
+      - powershell: |
+          $m2 = Join-Path $HOME '.m2'
+          New-Item -ItemType Directory -Path $m2 -Force | Out-Null
+          Copy-Item '$(Build.SourcesDirectory)/settings.xml' (Join-Path $m2 'settings.xml') -Force
+        displayName: 'Install Maven settings.xml'
+
       - task: MavenAuthenticate@0
         displayName: 'Authenticate Maven feed'
         inputs:
-          # Must match the <id> of the repositories declared in the pom.xml files.
-          artifactsFeeds: central
+          # Azure Artifacts feed name, which must match the <id> of the mirror in settings.xml.
+          artifactsFeeds: upstream-public
 
       - task: npmAuthenticate@0
         displayName: 'Authenticate npm feed'

--- a/eng/scripts/Install-MavenCredentialProvider.ps1
+++ b/eng/scripts/Install-MavenCredentialProvider.ps1
@@ -1,0 +1,156 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+    Bootstraps the Azure Artifacts Maven credential provider for local development.
+
+.DESCRIPTION
+    Maven packages for this repository are restored from an Azure Artifacts feed. Reads are
+    anonymous, so this script is only needed by Microsoft developers who have to ingest a package
+    version that the feed has not cached yet.
+
+    The script:
+      1. Verifies the credential provider is present in the local Maven repository, and downloads it
+         from the public AzureArtifacts tools feed if it is not.
+      2. Writes '.mvn/extensions.xml' at the root of the repository so Maven loads the provider.
+
+    '.mvn/' is intentionally listed in .gitignore. The extension exits when it detects a build
+    context, and committing it would force an authenticated restore on anonymous consumers. Azure
+    Pipelines uses the MavenAuthenticate@0 task instead.
+
+.PARAMETER Version
+    Version of the credential provider to install. Defaults to the version pinned by this script.
+
+.PARAMETER LocalRepositoryPath
+    Path to the local Maven repository. Defaults to '~/.m2/repository'.
+
+.PARAMETER Force
+    Overwrite an existing '.mvn/extensions.xml' even if it declares extensions this script does not
+    manage, and re-download the credential provider even when it is already installed.
+
+.EXAMPLE
+    ./eng/scripts/Install-MavenCredentialProvider.ps1
+
+.LINK
+    https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/maven-credprovider
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Version = '3.2.1',
+    [string] $LocalRepositoryPath,
+    [switch] $Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$groupId = 'com.microsoft.azure'
+$artifactId = 'artifacts-maven-credprovider'
+$bootstrapFeed = 'https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
+
+# Maven records the extension against this repository id. It must match the <id> of the repositories
+# declared in this repository's pom.xml files, otherwise resolution fails validation later.
+$repositoryId = 'central'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+
+if (-not (Get-Command mvn -ErrorAction SilentlyContinue)) {
+    throw "Maven ('mvn') was not found on PATH. Install Apache Maven 3.0 or above and try again."
+}
+
+if (-not $LocalRepositoryPath) {
+    $LocalRepositoryPath = Join-Path $HOME '.m2' 'repository'
+}
+
+$artifactDirectory = $LocalRepositoryPath
+foreach ($segment in ($groupId.Split('.') + @($artifactId, $Version))) {
+    $artifactDirectory = Join-Path $artifactDirectory $segment
+}
+
+$artifactPath = Join-Path $artifactDirectory "$artifactId-$Version.jar"
+
+if ((Test-Path $artifactPath) -and -not $Force) {
+    Write-Host "Credential provider $Version is already installed at '$artifactPath'."
+}
+else {
+    Write-Host "Installing credential provider $Version from the public tools feed..."
+
+    # The bootstrap must run outside of any Maven project so that this repository's own repository
+    # and extension configuration does not take part in resolving the extension itself.
+    $workingDirectory = Join-Path ([IO.Path]::GetTempPath()) ('credprovider-bootstrap-' + [Guid]::NewGuid().ToString('n'))
+    New-Item -ItemType Directory -Path $workingDirectory -Force | Out-Null
+
+    try {
+        Push-Location $workingDirectory
+        try {
+            $mvnArgs = @(
+                '--batch-mode'
+                'dependency:get'
+                "-Dartifact=${groupId}:${artifactId}:${Version}"
+                "-DremoteRepositories=${repositoryId}::::${bootstrapFeed}"
+            )
+
+            if ($PSBoundParameters.ContainsKey('LocalRepositoryPath')) {
+                $mvnArgs += "-Dmaven.repo.local=$LocalRepositoryPath"
+            }
+
+            & mvn @mvnArgs
+            if ($LASTEXITCODE -ne 0) {
+                throw "'mvn dependency:get' failed with exit code $LASTEXITCODE."
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    finally {
+        Remove-Item $workingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    if (-not (Test-Path $artifactPath)) {
+        throw "Bootstrap reported success but '$artifactPath' was not found. If a mirror is configured in your settings.xml, temporarily disable it and retry."
+    }
+
+    Write-Host "Installed credential provider to '$artifactPath'."
+}
+
+$extensionsDirectory = Join-Path $repoRoot '.mvn'
+$extensionsPath = Join-Path $extensionsDirectory 'extensions.xml'
+
+if ((Test-Path $extensionsPath) -and -not $Force) {
+    $existing = Get-Content $extensionsPath -Raw
+
+    if ($existing -notmatch [regex]::Escape($artifactId)) {
+        throw "'$extensionsPath' already exists and declares extensions this script does not manage. Review it manually, or re-run with -Force to overwrite it."
+    }
+
+    if ($existing -match "<version>\s*$([regex]::Escape($Version))\s*</version>") {
+        Write-Host "'$extensionsPath' is already configured for version $Version."
+        Write-Host 'Done.'
+        return
+    }
+}
+
+$extensionsContent = @"
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Generated by eng/scripts/Install-MavenCredentialProvider.ps1. Do not commit this file: it is
+  ignored by .gitignore because the extension exits inside build environments and would break
+  anonymous package restore for other consumers.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>$groupId</groupId>
+    <artifactId>$artifactId</artifactId>
+    <version>$Version</version>
+  </extension>
+</extensions>
+"@
+
+New-Item -ItemType Directory -Path $extensionsDirectory -Force | Out-Null
+Set-Content -Path $extensionsPath -Value $extensionsContent -Encoding utf8
+
+Write-Host "Wrote '$extensionsPath' for version $Version."
+Write-Host 'Done.'

--- a/eng/scripts/install-maven-credprovider.sh
+++ b/eng/scripts/install-maven-credprovider.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Bootstraps the Azure Artifacts Maven credential provider for local development.
+#
+# Maven packages for this repository are restored from an Azure Artifacts feed. Reads are anonymous,
+# so this script is only needed by Microsoft developers who have to ingest a package version that
+# the feed has not cached yet.
+#
+# The script:
+#   1. Verifies the credential provider is present in the local Maven repository, and downloads it
+#      from the public AzureArtifacts tools feed if it is not.
+#   2. Writes '.mvn/extensions.xml' at the root of the repository so Maven loads the provider.
+#
+# '.mvn/' is intentionally listed in .gitignore. The extension exits when it detects a build context,
+# and committing it would force an authenticated restore on anonymous consumers. Azure Pipelines
+# uses the MavenAuthenticate@0 task instead.
+#
+# See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/maven-credprovider
+
+set -euo pipefail
+
+GROUP_ID='com.microsoft.azure'
+ARTIFACT_ID='artifacts-maven-credprovider'
+BOOTSTRAP_FEED='https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1'
+
+# Maven records the extension against this repository id. It must match the <id> of the repositories
+# declared in this repository's pom.xml files, otherwise resolution fails validation later.
+REPOSITORY_ID='central'
+
+version='3.2.1'
+local_repository_path=''
+force=false
+
+usage() {
+    cat <<'EOF'
+Usage: install-maven-credprovider.sh [options]
+
+Options:
+  -v, --version <version>            Version of the credential provider to install.
+  -l, --local-repository <path>      Path to the local Maven repository. Defaults to ~/.m2/repository.
+  -f, --force                        Overwrite an unmanaged .mvn/extensions.xml and re-download the
+                                     credential provider even when it is already installed.
+  -h, --help                         Show this help text.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--version)
+            [[ $# -ge 2 ]] || { echo "error: $1 requires a value" >&2; exit 1; }
+            version="$2"
+            shift 2
+            ;;
+        -l|--local-repository)
+            [[ $# -ge 2 ]] || { echo "error: $1 requires a value" >&2; exit 1; }
+            local_repository_path="$2"
+            shift 2
+            ;;
+        -f|--force)
+            force=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument '$1'" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+
+if ! command -v mvn >/dev/null 2>&1; then
+    echo "error: Maven ('mvn') was not found on PATH. Install Apache Maven 3.0 or above and try again." >&2
+    exit 1
+fi
+
+local_repository_specified=true
+if [[ -z "$local_repository_path" ]]; then
+    local_repository_specified=false
+    local_repository_path="$HOME/.m2/repository"
+fi
+
+group_path="${GROUP_ID//./\/}"
+artifact_path="$local_repository_path/$group_path/$ARTIFACT_ID/$version/$ARTIFACT_ID-$version.jar"
+
+if [[ -f "$artifact_path" && "$force" != true ]]; then
+    echo "Credential provider $version is already installed at '$artifact_path'."
+else
+    echo "Installing credential provider $version from the public tools feed..."
+
+    # The bootstrap must run outside of any Maven project so that this repository's own repository
+    # and extension configuration does not take part in resolving the extension itself.
+    working_directory="$(mktemp -d)"
+    cleanup() { rm -rf "$working_directory"; }
+    trap cleanup EXIT
+
+    mvn_args=(
+        --batch-mode
+        dependency:get
+        "-Dartifact=${GROUP_ID}:${ARTIFACT_ID}:${version}"
+        "-DremoteRepositories=${REPOSITORY_ID}::::${BOOTSTRAP_FEED}"
+    )
+
+    if [[ "$local_repository_specified" == true ]]; then
+        mvn_args+=("-Dmaven.repo.local=$local_repository_path")
+    fi
+
+    (cd "$working_directory" && mvn "${mvn_args[@]}")
+
+    if [[ ! -f "$artifact_path" ]]; then
+        echo "error: bootstrap reported success but '$artifact_path' was not found." >&2
+        echo "If a mirror is configured in your settings.xml, temporarily disable it and retry." >&2
+        exit 1
+    fi
+
+    echo "Installed credential provider to '$artifact_path'."
+fi
+
+extensions_directory="$repo_root/.mvn"
+extensions_path="$extensions_directory/extensions.xml"
+
+if [[ -f "$extensions_path" && "$force" != true ]]; then
+    if ! grep -q "$ARTIFACT_ID" "$extensions_path"; then
+        echo "error: '$extensions_path' already exists and declares extensions this script does not manage." >&2
+        echo "Review it manually, or re-run with --force to overwrite it." >&2
+        exit 1
+    fi
+
+    if grep -qE "<version>[[:space:]]*${version//./\\.}[[:space:]]*</version>" "$extensions_path"; then
+        echo "'$extensions_path' is already configured for version $version."
+        echo 'Done.'
+        exit 0
+    fi
+fi
+
+mkdir -p "$extensions_directory"
+cat >"$extensions_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Generated by eng/scripts/install-maven-credprovider.sh. Do not commit this file: it is ignored by
+  .gitignore because the extension exits inside build environments and would break anonymous package
+  restore for other consumers.
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>$GROUP_ID</groupId>
+    <artifactId>$ARTIFACT_ID</artifactId>
+    <version>$version</version>
+  </extension>
+</extensions>
+EOF
+
+echo "Wrote '$extensions_path' for version $version."
+echo 'Done.'

--- a/java-library/README.md
+++ b/java-library/README.md
@@ -14,12 +14,24 @@ All Maven packages and plugins are restored from the `upstream-public` Azure Art
 (`https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1`), which is configured
 as the `central` repository in every `pom.xml` in this repository.
 
+The repository root also has a [`settings.xml`](../settings.xml) that mirrors `central` to the same
+feed. It exists because a `pom.xml` cannot cover everything:
+
+- Maven resolves build extensions and plugin prefixes *before* a pom's `<repositories>` are honored,
+  so those requests would otherwise go straight to Maven Central.
+- `MavenAuthenticate@0` and the credential provider key credentials off the Azure Artifacts *feed
+  name* (`upstream-public`), while the pom repository id must be `central` in order to override the
+  id Maven inherits from the Super POM. The mirror id bridges the two.
+
+CI installs this file to `~/.m2/settings.xml`. Locally you only need it when pulling a package or
+version the feed has not cached yet, in which case pass it explicitly with `mvn -s settings.xml`.
+
 ### Anonymous restore (default)
 
 The feed allows anonymous reads, so no credentials are required to build once a package version has
 been saved to the feed. External contributors and fresh clones need no setup — `mvn` just works.
-Never commit credentials or a `settings.xml` containing a `<server>` entry to this repository; doing
-so would force authentication on everyone.
+Never commit credentials or a `<server>` entry to `settings.xml` in this repository; doing so would
+force authentication on everyone.
 
 ### Authenticating (Microsoft developers only)
 

--- a/java-library/README.md
+++ b/java-library/README.md
@@ -8,6 +8,100 @@ This project contains the necessary annotations and classes needed for the inter
 * Install Java [supported version](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java?tabs=bash%2Cconsumption#java-versions)
 * [Apache maven](https://maven.apache.org/) 3.0 or above.
 
+## Package feed
+
+All Maven packages and plugins are restored from the `upstream-public` Azure Artifacts feed
+(`https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1`), which is configured
+as the `central` repository in every `pom.xml` in this repository.
+
+### Anonymous restore (default)
+
+The feed allows anonymous reads, so no credentials are required to build once a package version has
+been saved to the feed. External contributors and fresh clones need no setup — `mvn` just works.
+Never commit credentials or a `settings.xml` containing a `<server>` entry to this repository; doing
+so would force authentication on everyone.
+
+### Authenticating (Microsoft developers only)
+
+Authentication is only needed to *ingest* a package version that the feed has not cached yet. The
+first restore of any new or upgraded dependency will fail anonymously with:
+
+> No local versions of package '...'; please provide authentication to access versions from upstream
+> that have not yet been saved to your feed.
+
+When that happens, a Microsoft developer with access to the `azfunc/public` project must run the
+restore once with credentials, which pulls the version from upstream and saves it to the feed. Every
+subsequent anonymous restore then succeeds.
+
+The recommended way to authenticate is the `artifacts-maven-credprovider` which acquires a token via
+Entra ID so you don't have to manage a PAT.
+
+Run the helper script for your shell from the root of your clone. It installs the credential provider
+into your local Maven repository if it is missing, then writes `.mvn/extensions.xml`. Both scripts
+are idempotent, so re-running them is safe:
+
+```powershell
+./eng/scripts/Install-MavenCredentialProvider.ps1
+```
+
+```bash
+./eng/scripts/install-maven-credprovider.sh
+```
+
+Pass `-Version` / `--version` to install a different release, and `-Force` / `--force` to reinstall or
+to overwrite an `.mvn/extensions.xml` the script does not manage.
+
+If you would rather do it by hand, the equivalent steps are:
+
+1. Bootstrap the credential provider once per machine. Run this from a directory **outside** any
+   Maven project (e.g. your home directory) — it downloads the extension from the public
+   `AzureArtifacts` tools feed, which needs no authentication:
+
+   ```powershell
+   mvn dependency:get "-Dartifact=com.microsoft.azure:artifacts-maven-credprovider:3.2.1" "-DremoteRepositories=central::::https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1"
+   ```
+
+   Using the repository id `central` matters: Maven records the extension as having come from
+   `central`, which is the same id this repository's `pom.xml` files declare, so the cached copy
+   validates during later builds.
+
+2. Create `.mvn/extensions.xml` at the root of your clone:
+
+   ```xml
+   <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+     <extension>
+       <groupId>com.microsoft.azure</groupId>
+       <artifactId>artifacts-maven-credprovider</artifactId>
+       <version>3.2.1</version>
+     </extension>
+   </extensions>
+   ```
+
+`.mvn/` is deliberately listed in `.gitignore` — **do not commit it**. The extension exits when it
+detects a build context, and committing it would break anonymous restores for everyone else.
+
+If you would rather not use the credential provider, you can instead add a `<server>` entry to your
+**user-level** `~/.m2/settings.xml` (never to a file inside this repository), using an Azure DevOps
+personal access token with Packaging read & write scope:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <!-- Must match the <id> of the repository declared in the pom.xml files. -->
+      <id>central</id>
+      <username>azfunc</username>
+      <password>[PERSONAL_ACCESS_TOKEN]</password>
+    </server>
+  </servers>
+</settings>
+```
+
+CI covers this automatically: the `MavenAuthenticate@0` task in the build templates authenticates the
+`central` repository, so merged changes to dependency versions are ingested by the pipeline. The
+credential provider is not used in pipelines.
+
 ## Build and Test
 
 1. To build the java library locally, JDK 8 is required. Update the system variables - JAVA_HOME to jdk 8 path and add the jdk 8 bin path to PATH variable.

--- a/java-library/pom.xml
+++ b/java-library/pom.xml
@@ -58,19 +58,32 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
 	<repositories>
 		<repository>
-			<id>maven.snapshots</id>
-			<name>Maven Central Snapshot Repository</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<id>central</id>
+			<url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
 			<releases>
-				<enabled>false</enabled>
+				<enabled>true</enabled>
 			</releases>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
 	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>central</id>
+			<url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<dependencies>
 		<dependency>

--- a/java-library/pom.xml
+++ b/java-library/pom.xml
@@ -18,6 +18,7 @@
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.10.0</maven.javadoc.plugin.version>
         <maven.surefire.plugin.version>3.5.0</maven.surefire.plugin.version>
+        <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
 	</properties>
 
 	<licenses>
@@ -167,6 +168,13 @@
 						</property>
 					</systemProperties>
 				</configuration>
+			</plugin>
+			<!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve that
+			     prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${maven.checkstyle.plugin.version}</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/samples/assistant/java/pom.xml
+++ b/samples/assistant/java/pom.xml
@@ -132,6 +132,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/assistant/java/pom.xml
+++ b/samples/assistant/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/chat/java/pom.xml
+++ b/samples/chat/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/chat/java/pom.xml
+++ b/samples/chat/java/pom.xml
@@ -120,6 +120,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/embeddings/java/pom.xml
+++ b/samples/embeddings/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/embeddings/java/pom.xml
+++ b/samples/embeddings/java/pom.xml
@@ -120,6 +120,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/rag-aisearch/java/pom.xml
+++ b/samples/rag-aisearch/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/rag-aisearch/java/pom.xml
+++ b/samples/rag-aisearch/java/pom.xml
@@ -120,6 +120,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/rag-cosmosdb-nosql/java/pom.xml
+++ b/samples/rag-cosmosdb-nosql/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/rag-cosmosdb-nosql/java/pom.xml
+++ b/samples/rag-cosmosdb-nosql/java/pom.xml
@@ -120,6 +120,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/rag-cosmosdb/java/pom.xml
+++ b/samples/rag-cosmosdb/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/rag-cosmosdb/java/pom.xml
+++ b/samples/rag-cosmosdb/java/pom.xml
@@ -120,6 +120,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/rag-kusto/java/pom.xml
+++ b/samples/rag-kusto/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/rag-kusto/java/pom.xml
+++ b/samples/rag-kusto/java/pom.xml
@@ -120,6 +120,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/textcompletion/java/pom.xml
+++ b/samples/textcompletion/java/pom.xml
@@ -19,6 +19,21 @@
         <functionAppName>azfs-java-openai-sample</functionAppName>
     </properties>
 
+    <!-- Package sources must be routed through an Azure Artifacts feed (CFS). -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/samples/textcompletion/java/pom.xml
+++ b/samples/textcompletion/java/pom.xml
@@ -120,6 +120,13 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <!-- CI runs `checkstyle:checkstyle`. Declaring the plugin here lets Maven resolve
+                 that prefix from the project, instead of from the plugin group maven-metadata.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings for Central Feed Service (CFS).
+
+  The pom.xml files in this repo override the `central` repository so every package is served by
+  the Azure Artifacts feed below. Anonymous reads of packages already saved to the feed work
+  without this file, so most contributors never need it.
+
+  It exists because the repository id and the credential id cannot be the same value:
+
+    * The pom repository id must be `central` in order to override the id Maven inherits from the
+      Super POM. Anything else leaves the real Maven Central in the resolution list (CFS0021).
+    * MavenAuthenticate@0 and the Azure Artifacts credential provider key credentials off the
+      *feed name* (`upstream-public`), not the repository id.
+
+  A mirror bridges the two: requests for `central` are redirected to the feed, and the mirror id
+  matches the feed name so credentials line up.
+
+  CI installs this file to ~/.m2/settings.xml. To use it locally (only needed when pulling a
+  package or version the feed has not cached yet):
+
+      mvn -s settings.xml <goals>
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>upstream-public</id>
+      <name>Azure Functions public upstream feed</name>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
Follow-up to #217, which onboarded npm and NuGet restores to the Central Feed Service. This does the same for Maven.

All Maven packages and plugins now restore from the `azfunc/public` `upstream-public` Azure Artifacts feed — the same feed already used by `.npmrc` and `NuGet.config`.

## CFS detectors addressed

- **CFS0021** (missing explicit `central` override) — all nine `pom.xml` files now declare `central` for both `<repositories>` and `<pluginRepositories>`.
- **CFS0022** (external feed in a pom) — `java-library/pom.xml` no longer points at `oss.sonatype.org` for snapshots. `<distributionManagement>` is left alone, since that's a publish target rather than a package source.

## Anonymous by default

The feed serves cached packages anonymously, so external contributors and fresh clones need no credentials. Authentication is only needed to *ingest* a version the feed hasn't cached yet.

- **CI** authenticates with `MavenAuthenticate@0` ahead of the Maven tasks, so merged dependency bumps get ingested by the pipeline.
- **Local developers** can opt in to the Azure Artifacts Maven credential provider (Entra ID, no PAT) via new helper scripts in `eng/scripts`. A PAT in `~/.m2/settings.xml` remains a documented fallback.

`.mvn/` is gitignored on purpose. Per the [Azure Artifacts guidance](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/maven-credprovider), the extension exits when it detects a build context, and committing it would impose an authenticated restore on anonymous consumers.

## Helper scripts

`eng/scripts/Install-MavenCredentialProvider.ps1` and `eng/scripts/install-maven-credprovider.sh` check whether the provider is already in the local Maven repo, bootstrap it from the public tools feed only if missing, then write `.mvn/extensions.xml`. Both are idempotent, support version/local-repo/force options, and refuse to clobber an `extensions.xml` they don't manage.

Both were run end-to-end against a throwaway local repository: fresh install pulls 3.2.1 anonymously, re-runs no-op, the unmanaged-file guard exits non-zero with the file intact, and `--force` overwrites.

## Note on `.gitattributes`

Slightly beyond the core change, but required. The repo has `core.autocrlf=true` and no attributes file, so a committed `.sh` would be checked out with CRLF on Windows and fail under bash (`syntax error near unexpected token $'{\r'`). Added `*.sh text eol=lf`.

## Follow-up

The Maven feed currently has **nothing cached** — `maven-compiler-plugin`, `org.json:json`, and `azure-functions-maven-plugin` all return 401 with *"no local versions... provide authentication to access versions from upstream."* Worth running the Java pipeline on this branch before merging so the feed is warmed, otherwise the first anonymous consumer hits that error.