### PR TITLE
Restore SDL baselines and own autobaselining in GitHub

### DIFF
--- a/.config/1espt/PipelineAutobaseliningConfig.yml
+++ b/.config/1espt/PipelineAutobaseliningConfig.yml
@@ -19,3 +19,20 @@ pipelines:
           lastModifiedDate: 2024-07-22
         armory:
           lastModifiedDate: 2024-07-22
+  558:
+    retail:
+      source:
+        eslint:
+          lastModifiedDate: 2026-07-23
+        armory:
+          lastModifiedDate: 2026-07-23
+  559:
+    retail:
+      binary:
+        binskim:
+          lastModifiedDate: 2026-07-23
+      source:
+        eslint:
+          lastModifiedDate: 2026-07-23
+        armory:
+          lastModifiedDate: 2026-07-23

--- a/.config/1espt/PipelineAutobaseliningConfig.yml
+++ b/.config/1espt/PipelineAutobaseliningConfig.yml
@@ -1,0 +1,21 @@
+## DO NOT MODIFY THIS FILE MANUALLY. This is part of auto-baselining from 1ES Pipeline Templates. Go to [https://aka.ms/1espt-autobaselining] for more details.
+
+pipelines:
+  557:
+    retail:
+      binary:
+        credscan:
+          lastModifiedDate: 2024-07-22
+        binskim:
+          lastModifiedDate: 2025-03-04
+        spotbugs:
+          lastModifiedDate: 2024-07-22
+      source:
+        credscan:
+          lastModifiedDate: 2024-07-22
+        eslint:
+          lastModifiedDate: 2024-07-22
+        psscriptanalyzer:
+          lastModifiedDate: 2024-07-22
+        armory:
+          lastModifiedDate: 2024-07-22

--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -1,0 +1,28 @@
+{
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/baselines"
+  },
+  "version": "1.0.0",
+  "baselines": {
+    "default": {
+      "name": "default",
+      "createdDate": "2024-07-22 00:19:48Z",
+      "lastUpdatedDate": "2024-07-22 00:19:48Z"
+    }
+  },
+  "results": {
+    "b3736a918ff8d688843a2c76bfce1661c484e260144140c9df23f1147da102c0": {
+      "signature": "b3736a918ff8d688843a2c76bfce1661c484e260144140c9df23f1147da102c0",
+      "alternativeSignatures": [],
+      "target": "spotbugs.xml",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "spotbugs",
+      "ruleId": "gdn.unknownFormatResult",
+      "createdDate": "2024-07-22 00:19:48Z",
+      "expirationDate": "2025-01-08 00:23:50Z",
+      "justification": "This error is baselined with an expiration date of 180 days from 2024-07-22 00:23:50Z"
+    }
+  }
+}

--- a/eng/ci/public-build-java.yml
+++ b/eng/ci/public-build-java.yml
@@ -48,6 +48,10 @@ extends:
       os: windows
 
     sdl:
+      # GitHub is the source of truth; the ADO repo is a one-way mirror, so
+      # autobaselining pull requests must be raised against GitHub.
+      autobaseline:
+        enableForGitHub: true
       codeql:
         compiled:
           enabled: true # still only runs for default branch

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -44,6 +44,10 @@ extends:
       os: windows
 
     sdl:
+      # GitHub is the source of truth; the ADO repo is a one-way mirror, so
+      # autobaselining pull requests must be raised against GitHub.
+      autobaseline:
+        enableForGitHub: true
       codeql:
         compiled:
           enabled: true # still only runs for default branch


### PR DESCRIPTION
## Problem

The official build (`openai-extension.official`, pipeline `557`) fails in `BuildJavaLibrary`:

```
SpotBugs Error gdn.unknownFormatResult - File: spotbugs.xml
Guardian detected one or more breaking results
Guardian exited with an error exit code: 8
```

First failure: [build 295503](https://dev.azure.com/azfunc/internal/_build/results?buildId=295503&view=results), still failing as of [295877](https://dev.azure.com/azfunc/internal/_build/results?buildId=295877&view=results).

## The SpotBugs finding is not new

SpotBugs 4.7.3.1 throws an NPE in `ReflectionIncreaseAccessibility.sawOpcode` while analyzing `javassist.util.proxy.DefineClassHelper`, which it reaches via the `-auxclasspath` that the 1ES task points at the entire `~/.m2` tree. The resulting `<Error>` node in `spotbugs.xml` can't be mapped to a rule, so Guardian surfaces it as `gdn.unknownFormatResult`.

The byte-for-byte identical NPE is present in the **last passing** build ([295197](https://dev.azure.com/azfunc/internal/_build/results?buildId=295197&view=results)). `SpotBugs completed with exit code 0` in both — the break comes from `guardian.cmd pipeline-break`. Nothing about the Java build changed; the finding was simply baselined before.

## Root cause

MerlinBot generated the baseline files in the ADO mirror as PR 680 ("Auto-generated baselines by 1ES Pipeline Templates"). That PR was **abandoned** on `2026-08-03T18:35:09Z`. Build 295503 queued at `18:37:08Z` — two minutes later.

While the PR was open, 1ES resolved the baseline straight off the bot's branch. Once abandoned, it falls back to the in-repo path, which had never been merged:

| `Auto-baselining mode and SDL pre-checks (1ES PT)` | 295197 — passed | 295503 / 295877 — failed |
| --- | --- | --- |
| autobaselining PR | `Found an active autobaselining PR` | `No active autobaselining PR found` |
| `OneES_Local_Fallback_Retail_Baseline_File_Path` | `…\gdn_baseline\autobaselining_pr_branch\.gdnbaselines` | `…\s\.config\guardian\.gdnbaselines` → **not found** |
| Guardian | `Baselined results: 1` → `Found no breaking results` | `Baselined results: 0` → `Active results: 1` → break |

The baselined signature `b3736a918ff8d688843a2c76bfce1661c484e260144140c9df23f1147da102c0` is exactly the one Guardian now reports as breaking, and `tool` / `ruleId` / `target` all match.

## Why the ADO PR was never the right place to fix it

Pipelines split across two repos:

| Pipeline | Repo it builds | MerlinBot raises PRs in |
| --- | --- | --- |
| 557 `openai-extension.official` | ADO mirror `azure.azure-functions-openai-extension` (TfsGit) | ADO |
| 1338 `openai-extension.release` | ADO mirror (TfsGit) | ADO |
| 558 `openai-extension.public` | **GitHub** `Azure/azure-functions-openai-extension` | GitHub |
| 559 `openai-extension.public-java` | **GitHub** | GitHub |

The ADO repo is a one-way mirror of this one (`eng/ci/code-mirror.yml`), so a baselining PR completed there is overwritten on the next sync. The files have to be owned here.

## Changes

**1. Restore the baseline files** (verbatim as MerlinBot generated them)

- `.config/guardian/.gdnbaselines` — the actual fix
- `.config/1espt/PipelineAutobaseliningConfig.yml`

**2. Make GitHub autobaselining explicit** on the two GitHub-backed pipelines, per the [1ES guidance for GitHub repos](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/autobaselining):

```yaml
sdl:
  autobaseline:
    enableForGitHub: true
```

**3. Fold in the config MerlinBot already generated for 558/559**

MerlinBot has in fact been baselining the public pipelines here all along — it pushed config for `558` and `559` to `users/merlinbot/1es-pt-auto-baselining-pr` on 2026-07-23 but raised no PR, which is the [documented behaviour](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/autobaselining) when no update to `.gdnbaselines` is required. Those entries are folded in verbatim, so `PipelineAutobaseliningConfig.yml` now covers `557`, `558` and `559` rather than just `557`.

Note that pipeline 559 runs the same `eng/ci/templates/build-java-library.yml` as 557, so the SpotBugs scan — and the baselined finding — is identical between them.

No changes to build logic or poms. Both baseline files validated as parseable JSON / YAML; the `557` block is untouched from PR 680 and the `558` / `559` blocks are byte-identical to the bot's output.
